### PR TITLE
NOISSUE - Fix curl examples for HTTPS proxy usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Cube AI uses TEEs to protect user data and AI models from unauthorized access. T
    
    List available models (replace `YOUR_DOMAIN_ID` with the domain ID from step 4):
    ```bash
-   curl http://localhost/proxy/YOUR_DOMAIN_ID/v1/models \
+   curl -k https://localhost/proxy/YOUR_DOMAIN_ID/v1/models \
      -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
    ```
 
@@ -136,7 +136,7 @@ Cube AI uses TEEs to protect user data and AI models from unauthorized access. T
    
    Replace `YOUR_DOMAIN_ID` with your actual domain ID:
    ```bash
-   curl http://localhost/proxy/YOUR_DOMAIN_ID/v1/chat/completions \
+   curl -k https://localhost/proxy/YOUR_DOMAIN_ID/v1/chat/completions \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
      -d '{


### PR DESCRIPTION
<!--
Copyright (c) Ultraviolet
SPDX-License-Identifier: Apache-2.0
-->

<!--

Pull request title should be `UV-XXX - description` or `COCOS-XXX - description` or `NOISSUE - description` where XXX is the ID of the issue that this PR relate to. Please review the [CONTRIBUTING.md](https://github.com/ultravioletrs/.github/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please avoid force-pushing additional commits for a timely review/response if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits.
- Update any related documentation.
-->

# What type of PR is this?

This is a documentation update because it fixes incorrect curl examples in the README.

## What does this do?

Updates the README curl examples to correctly use HTTPS and the `-k` flag when calling the proxy endpoint.



## Which issue(s) does this PR fix/relate to?

- NOISSUE




## Have you included tests for your changes?
No
## Did you document any new/modified features?

Yes, existing documentation was corrected


### Notes

