### PR TITLE
Add domain isolation to embedder and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ docker/data/
 # Filesystem
 *.ext4
 *.backup
+
+# Compiled binaries
+embedder
+
+# Vite cache
+ui/.vite/

--- a/Makefile
+++ b/Makefile
@@ -161,12 +161,12 @@ endif
 .PHONY: up-ollama
 up-ollama: config-ollama
 	@echo "Starting Cube with Ollama backend..."
-	docker compose -f docker/compose.yaml --profile default up -d
+	docker compose -f docker/compose.yaml -f docker/cube-compose.yaml --env-file docker/.env --profile default up -d
 
 .PHONY: up-vllm
 up-vllm: config-vllm
 	@echo "Starting Cube with vLLM backend..."
-	docker compose -f docker/compose.yaml --profile vllm up -d
+	docker compose -f docker/compose.yaml -f docker/cube-compose.yaml --env-file docker/.env --profile vllm up -d
 
 GUARDRAILS_CONFIG_FILE = ./guardrails/rails/config.yml
 

--- a/docker/Dockerfile.embedder
+++ b/docker/Dockerfile.embedder
@@ -4,7 +4,7 @@
 # Build the embedder binary from local source.
 FROM golang:1.26.0-alpine AS builder
 WORKDIR /src
-COPY .. .
+COPY . .
 RUN apk add --no-cache git && \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build -ldflags "-s -w" -o /exe ./cmd/embedder/main.go

--- a/internal/embedder/api/transport/chat.go
+++ b/internal/embedder/api/transport/chat.go
@@ -6,6 +6,7 @@ package transport
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -27,6 +28,7 @@ type chatRequest struct {
 func chatHandler(svc domain.ChatService, conversations domain.ConversationRepository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
 		var req chatRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -43,9 +45,11 @@ func chatHandler(svc domain.ChatService, conversations domain.ConversationReposi
 		isNew := convID == ""
 		if isNew && conversations != nil {
 			title := conversationTitle(req.Messages)
-			conv, err := conversations.Create(r.Context(), userID, title)
+			conv, err := conversations.Create(r.Context(), domainID, userID, title)
 			if err == nil {
 				convID = conv.ID
+			} else {
+				slog.Warn("create conversation failed", "err", err, "domain_id", domainID, "user_id", userID)
 			}
 		}
 
@@ -54,7 +58,7 @@ func chatHandler(svc domain.ChatService, conversations domain.ConversationReposi
 			_ = conversations.AppendMessages(r.Context(), convID, toDomainMessages(req.Messages))
 		}
 
-		events, err := svc.Chat(r.Context(), userID, req.Messages, req.RecordIDs)
+		events, err := svc.Chat(r.Context(), domainID, req.Messages, req.RecordIDs)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("chat failed: "+err.Error()))
 			return

--- a/internal/embedder/api/transport/conversations.go
+++ b/internal/embedder/api/transport/conversations.go
@@ -64,8 +64,8 @@ func listConversations(repo domain.ConversationRepository) http.HandlerFunc {
 		Conversations []conversationResponse `json:"conversations"`
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		userID := auth.UserID(r.Context())
-		convs, err := repo.List(r.Context(), userID)
+		domainID := auth.DomainID(r.Context())
+		convs, err := repo.List(r.Context(), domainID)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("internal error"))
 			return
@@ -89,7 +89,8 @@ func createConversation(repo domain.ConversationRepository) http.HandlerFunc {
 			return
 		}
 		userID := auth.UserID(r.Context())
-		conv, err := repo.Create(r.Context(), userID, req.Title)
+		domainID := auth.DomainID(r.Context())
+		conv, err := repo.Create(r.Context(), domainID, userID, req.Title)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("internal error"))
 			return
@@ -105,9 +106,9 @@ func getConversation(repo domain.ConversationRepository) http.HandlerFunc {
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		conv, err := repo.Get(r.Context(), id, userID)
+		conv, err := repo.Get(r.Context(), id, domainID)
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				writeJSON(w, http.StatusNotFound, errBody("conversation not found"))
@@ -117,7 +118,7 @@ func getConversation(repo domain.ConversationRepository) http.HandlerFunc {
 			return
 		}
 
-		msgs, err := repo.ListMessages(r.Context(), id, userID)
+		msgs, err := repo.ListMessages(r.Context(), id, domainID)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("internal error"))
 			return
@@ -137,9 +138,9 @@ func getConversation(repo domain.ConversationRepository) http.HandlerFunc {
 func deleteConversation(repo domain.ConversationRepository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		if err := repo.Delete(r.Context(), id, userID); err != nil {
+		if err := repo.Delete(r.Context(), id, domainID); err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				writeJSON(w, http.StatusNotFound, errBody("conversation not found"))
 				return
@@ -161,10 +162,10 @@ func appendMessages(repo domain.ConversationRepository) http.HandlerFunc {
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		// Verify ownership before appending.
-		if _, err := repo.Get(r.Context(), id, userID); err != nil {
+		// Verify domain ownership before appending.
+		if _, err := repo.Get(r.Context(), id, domainID); err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				writeJSON(w, http.StatusNotFound, errBody("conversation not found"))
 				return

--- a/internal/embedder/api/transport/records.go
+++ b/internal/embedder/api/transport/records.go
@@ -103,9 +103,9 @@ type recordListResponse struct {
 func getRecord(svc domain.RecordService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		rec, err := svc.GetByID(r.Context(), id, userID)
+		rec, err := svc.GetByID(r.Context(), id, domainID)
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				writeJSON(w, http.StatusNotFound, errBody("record not found"))
@@ -120,11 +120,11 @@ func getRecord(svc domain.RecordService) http.HandlerFunc {
 
 func listRecords(svc domain.RecordService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 		p := parsePage(r)
 		f := parseRecordFilter(r)
 
-		page, err := svc.List(r.Context(), userID, f, p)
+		page, err := svc.List(r.Context(), domainID, f, p)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("internal error"))
 			return
@@ -135,13 +135,13 @@ func listRecords(svc domain.RecordService) http.HandlerFunc {
 
 func listRecordsBySource(svc domain.RecordService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 		sourceID := chi.URLParam(r, "source_id")
 		p := parsePage(r)
 		f := parseRecordFilter(r)
 		f.SourceID = &sourceID
 
-		page, err := svc.List(r.Context(), userID, f, p)
+		page, err := svc.List(r.Context(), domainID, f, p)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("internal error"))
 			return
@@ -153,9 +153,9 @@ func listRecordsBySource(svc domain.RecordService) http.HandlerFunc {
 func deleteRecord(svc domain.RecordService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		if err := svc.Delete(r.Context(), id, userID); err != nil {
+		if err := svc.Delete(r.Context(), id, domainID); err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				writeJSON(w, http.StatusNotFound, errBody("record not found"))
 				return
@@ -170,9 +170,9 @@ func deleteRecord(svc domain.RecordService) http.HandlerFunc {
 func retryRecord(svc domain.RecordService, trigger func()) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		if err := svc.RetryIngest(r.Context(), id, userID); err != nil {
+		if err := svc.RetryIngest(r.Context(), id, domainID); err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				writeJSON(w, http.StatusNotFound, errBody("record not found"))
 				return

--- a/internal/embedder/api/transport/records_upload.go
+++ b/internal/embedder/api/transport/records_upload.go
@@ -66,6 +66,7 @@ func uploadRecord(
 		defer src.Close()
 
 		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 		recordName := strings.TrimSpace(r.FormValue("name"))
 		sourceID := strings.TrimSpace(r.FormValue("source_id"))
 		if recordName == "" {
@@ -90,7 +91,7 @@ func uploadRecord(
 			return
 		}
 
-		source, err := resolveUploadSource(r.Context(), sourcesSvc, userID, sourceID)
+		source, err := resolveUploadSource(r.Context(), sourcesSvc, domainID, userID, sourceID)
 		if err != nil {
 			switch {
 			case errors.Is(err, domain.ErrNotFound):
@@ -118,6 +119,7 @@ func uploadRecord(
 		}
 
 		rec, err := recordsSvc.Create(r.Context(), domain.Record{
+			DomainID:   domainID,
 			UserID:     userID,
 			SourceID:   source.ID,
 			Name:       recordName,
@@ -184,10 +186,10 @@ func prepareUploadObjectKey(prefix, userID, originalName string) (string, error)
 func resolveUploadSource(
 	ctx context.Context,
 	sourcesSvc domain.SourceService,
-	userID, sourceID string,
+	domainID, userID, sourceID string,
 ) (domain.Source, error) {
 	if sourceID != "" {
-		src, err := sourcesSvc.GetByID(ctx, sourceID, userID)
+		src, err := sourcesSvc.GetByID(ctx, sourceID, domainID)
 		if err != nil {
 			return domain.Source{}, err
 		}
@@ -196,19 +198,19 @@ func resolveUploadSource(
 		}
 		return src, nil
 	}
-	return ensureDirectUploadSource(ctx, sourcesSvc, userID)
+	return ensureDirectUploadSource(ctx, sourcesSvc, domainID, userID)
 }
 
 func ensureDirectUploadSource(
 	ctx context.Context,
 	sourcesSvc domain.SourceService,
-	userID string,
+	domainID, userID string,
 ) (domain.Source, error) {
 	const pageLimit uint64 = 100
 	var offset uint64
 
 	for {
-		page, err := sourcesSvc.List(ctx, userID, domain.Page{Limit: pageLimit, Offset: offset})
+		page, err := sourcesSvc.List(ctx, domainID, domain.Page{Limit: pageLimit, Offset: offset})
 		if err != nil {
 			return domain.Source{}, err
 		}
@@ -231,6 +233,7 @@ func ensureDirectUploadSource(
 	}
 
 	created, err := sourcesSvc.Create(ctx, domain.Source{
+		DomainID:         domainID,
 		UserID:           userID,
 		Type:             domain.SourceTypeLocalFS,
 		Name:             directUploadSourceName,
@@ -246,7 +249,7 @@ func ensureDirectUploadSource(
 		return domain.Source{}, err
 	}
 
-	page, listErr := sourcesSvc.List(ctx, userID, domain.Page{Limit: pageLimit, Offset: 0})
+	page, listErr := sourcesSvc.List(ctx, domainID, domain.Page{Limit: pageLimit, Offset: 0})
 	if listErr != nil {
 		return domain.Source{}, listErr
 	}

--- a/internal/embedder/api/transport/retrieve.go
+++ b/internal/embedder/api/transport/retrieve.go
@@ -29,7 +29,7 @@ type retrieveResponse struct {
 
 func retrieveHandler(svc domain.VectorRetrieveService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
 		var req retrieveRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -41,7 +41,7 @@ func retrieveHandler(svc domain.VectorRetrieveService) http.HandlerFunc {
 			return
 		}
 
-		chunks, err := svc.Retrieve(r.Context(), userID, req.Query, req.RecordIDs, req.TopK)
+		chunks, err := svc.Retrieve(r.Context(), domainID, req.Query, req.RecordIDs, req.TopK)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("retrieve failed"))
 			return

--- a/internal/embedder/api/transport/sources.go
+++ b/internal/embedder/api/transport/sources.go
@@ -1145,6 +1145,7 @@ func createSource(svc domain.SourceService, oauth *googleOAuth) http.HandlerFunc
 		}
 
 		src := domain.Source{
+			DomainID:         auth.DomainID(r.Context()),
 			UserID:           auth.UserID(r.Context()),
 			Type:             domain.SourceType(req.SourceType),
 			Name:             req.Name,
@@ -1171,9 +1172,9 @@ func createSource(svc domain.SourceService, oauth *googleOAuth) http.HandlerFunc
 func getSource(svc domain.SourceService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		src, err := svc.GetByID(r.Context(), id, userID)
+		src, err := svc.GetByID(r.Context(), id, domainID)
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				writeJSON(w, http.StatusNotFound, errBody("source not found"))
@@ -1195,9 +1196,9 @@ func listSources(svc domain.SourceService) http.HandlerFunc {
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		p := parsePage(r)
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		page, err := svc.List(r.Context(), userID, p)
+		page, err := svc.List(r.Context(), domainID, p)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("internal error"))
 			return
@@ -1217,9 +1218,9 @@ func listSources(svc domain.SourceService) http.HandlerFunc {
 func deleteSource(svc domain.SourceService) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		if err := svc.Delete(r.Context(), id, userID); err != nil {
+		if err := svc.Delete(r.Context(), id, domainID); err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				writeJSON(w, http.StatusNotFound, errBody("source not found"))
 				return
@@ -1243,9 +1244,9 @@ func syncSource(syncSvc domain.SourceSyncService, trigger func()) http.HandlerFu
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
-		res, err := syncSvc.Sync(r.Context(), id, userID)
+		res, err := syncSvc.Sync(r.Context(), id, domainID)
 		if err != nil {
 			switch {
 			case errors.Is(err, domain.ErrNotFound):
@@ -1281,7 +1282,7 @@ func updateSourceCredentials(svc domain.SourceService) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
 		var req request
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1289,7 +1290,7 @@ func updateSourceCredentials(svc domain.SourceService) http.HandlerFunc {
 			return
 		}
 
-		updated, err := svc.UpdateGoogleDriveCredentials(r.Context(), id, userID, domain.GoogleDriveCredentialUpdate{
+		updated, err := svc.UpdateGoogleDriveCredentials(r.Context(), id, domainID, domain.GoogleDriveCredentialUpdate{
 			AccessToken:  req.AccessToken,
 			RefreshToken: req.RefreshToken,
 			ClientID:     req.ClientID,
@@ -1317,7 +1318,7 @@ func updateSourceSelection(svc domain.SourceService) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		userID := auth.UserID(r.Context())
+		domainID := auth.DomainID(r.Context())
 
 		var req request
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1325,7 +1326,7 @@ func updateSourceSelection(svc domain.SourceService) http.HandlerFunc {
 			return
 		}
 
-		updated, err := svc.UpdateGoogleDriveSelection(r.Context(), id, userID, domain.GoogleDriveSelectionUpdate{
+		updated, err := svc.UpdateGoogleDriveSelection(r.Context(), id, domainID, domain.GoogleDriveSelectionUpdate{
 			SelectedFileIDs:   req.SelectedFileIDs,
 			SelectedFolderIDs: req.SelectedFolderIDs,
 		})

--- a/internal/embedder/auth/middleware.go
+++ b/internal/embedder/auth/middleware.go
@@ -96,7 +96,7 @@ func Middleware(auth *Authenticator) func(http.Handler) http.Handler {
 			}
 
 			ctx := context.WithValue(r.Context(), userIDKey, userID)
-			if domainID := r.Header.Get("X-Domain-ID"); domainID != "" {
+			if domainID := r.Header.Get("X-Domain-Id"); domainID != "" {
 				ctx = context.WithValue(ctx, domainIDKey, domainID)
 			}
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/embedder/auth/middleware.go
+++ b/internal/embedder/auth/middleware.go
@@ -22,7 +22,10 @@ import (
 
 type contextKey string
 
-const userIDKey contextKey = "user_id"
+const (
+	userIDKey   contextKey = "user_id"
+	domainIDKey contextKey = "domain_id"
+)
 
 // Authenticator wraps the SuperMQ AuthService gRPC client.
 type Authenticator struct {
@@ -93,6 +96,9 @@ func Middleware(auth *Authenticator) func(http.Handler) http.Handler {
 			}
 
 			ctx := context.WithValue(r.Context(), userIDKey, userID)
+			if domainID := r.Header.Get("X-Domain-ID"); domainID != "" {
+				ctx = context.WithValue(ctx, domainIDKey, domainID)
+			}
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
@@ -101,6 +107,12 @@ func Middleware(auth *Authenticator) func(http.Handler) http.Handler {
 // UserID extracts the authenticated user ID from a request context.
 func UserID(ctx context.Context) string {
 	v, _ := ctx.Value(userIDKey).(string)
+	return v
+}
+
+// DomainID extracts the domain ID from a request context (set from X-Domain-ID header).
+func DomainID(ctx context.Context) string {
+	v, _ := ctx.Value(domainIDKey).(string)
 	return v
 }
 

--- a/internal/embedder/domain/chat.go
+++ b/internal/embedder/domain/chat.go
@@ -48,5 +48,5 @@ type ChatService interface {
 	// Chat embeds the query, retrieves relevant chunks, calls the LLM, and
 	// streams events to the returned channel.  The channel is closed when the
 	// stream ends (either successfully or after an error event).
-	Chat(ctx context.Context, userID string, messages []ChatMessage, recordIDs []string) (<-chan ChatEvent, error)
+	Chat(ctx context.Context, domainID string, messages []ChatMessage, recordIDs []string) (<-chan ChatEvent, error)
 }

--- a/internal/embedder/domain/conversation.go
+++ b/internal/embedder/domain/conversation.go
@@ -8,11 +8,12 @@ import (
 	"time"
 )
 
-// Conversation is a persisted chat session belonging to a user.
+// Conversation is a persisted chat session belonging to a domain.
 type Conversation struct {
-	ID        string
-	UserID    string
-	Title     string
+	ID       string
+	DomainID string
+	UserID   string
+	Title    string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -28,10 +29,10 @@ type ConversationMessage struct {
 
 // ConversationRepository is the persistence interface for conversations.
 type ConversationRepository interface {
-	Create(ctx context.Context, userID, title string) (Conversation, error)
-	List(ctx context.Context, userID string) ([]Conversation, error)
-	Get(ctx context.Context, id, userID string) (Conversation, error)
-	Delete(ctx context.Context, id, userID string) error
+	Create(ctx context.Context, domainID, userID, title string) (Conversation, error)
+	List(ctx context.Context, domainID string) ([]Conversation, error)
+	Get(ctx context.Context, id, domainID string) (Conversation, error)
+	Delete(ctx context.Context, id, domainID string) error
 	AppendMessages(ctx context.Context, conversationID string, msgs []ConversationMessage) error
-	ListMessages(ctx context.Context, conversationID, userID string) ([]ConversationMessage, error)
+	ListMessages(ctx context.Context, conversationID, domainID string) ([]ConversationMessage, error)
 }

--- a/internal/embedder/domain/record.go
+++ b/internal/embedder/domain/record.go
@@ -36,7 +36,9 @@ const (
 // so that vectorized content can be traced back to its origin at any time.
 type Record struct {
 	ID string
-	// UserID scopes this record to a single authenticated user.
+	// DomainID scopes this record to a domain (workspace); all domain members share it.
+	DomainID string
+	// UserID records the creating user for audit purposes.
 	UserID string
 	// SourceID links back to the Source this record was ingested from.
 	SourceID string
@@ -117,12 +119,12 @@ type RecordUpsertResult struct {
 // RecordRepository defines the persistence contract for records.
 type RecordRepository interface {
 	Create(ctx context.Context, r Record) (Record, error)
-	GetByID(ctx context.Context, id, userID string) (Record, error)
-	List(ctx context.Context, userID string, f RecordFilter, p Page) (RecordPage, error)
-	Delete(ctx context.Context, id, userID string) error
-	DeleteBySourceExternalIDs(ctx context.Context, userID, sourceID string, externalIDs []string) (int, error)
+	GetByID(ctx context.Context, id, domainID string) (Record, error)
+	List(ctx context.Context, domainID string, f RecordFilter, p Page) (RecordPage, error)
+	Delete(ctx context.Context, id, domainID string) error
+	DeleteBySourceExternalIDs(ctx context.Context, domainID, sourceID string, externalIDs []string) (int, error)
 	UpsertFromSource(ctx context.Context, r Record) (RecordUpsertResult, error)
-	// ListQueued returns up to limit records in "queued" status, across all users.
+	// ListQueued returns up to limit records in "queued" status, across all domains.
 	ListQueued(ctx context.Context, limit int) ([]Record, error)
 	// UpdateStatus transitions a record to the given status (and clears/sets error).
 	UpdateStatus(ctx context.Context, id string, s RecordStatus, errMsg string) error
@@ -133,8 +135,8 @@ type RecordRepository interface {
 // RecordService defines the business-logic contract for records.
 type RecordService interface {
 	Create(ctx context.Context, r Record) (Record, error)
-	GetByID(ctx context.Context, id, userID string) (Record, error)
-	List(ctx context.Context, userID string, f RecordFilter, p Page) (RecordPage, error)
-	Delete(ctx context.Context, id, userID string) error
-	RetryIngest(ctx context.Context, id, userID string) error
+	GetByID(ctx context.Context, id, domainID string) (Record, error)
+	List(ctx context.Context, domainID string, f RecordFilter, p Page) (RecordPage, error)
+	Delete(ctx context.Context, id, domainID string) error
+	RetryIngest(ctx context.Context, id, domainID string) error
 }

--- a/internal/embedder/domain/retrieval.go
+++ b/internal/embedder/domain/retrieval.go
@@ -5,7 +5,7 @@ package domain
 
 import "context"
 
-// RetrievalQuery defines a user-scoped chunk retrieval request.
+// RetrievalQuery defines a domain-scoped chunk retrieval request.
 type RetrievalQuery struct {
 	Query     string
 	RecordIDs []string
@@ -35,10 +35,10 @@ type RetrievalResult struct {
 
 // RetrievalRepository provides low-level retrieval over stored chunks.
 type RetrievalRepository interface {
-	KeywordSearchChunks(ctx context.Context, userID string, q RetrievalQuery) ([]ChunkMatch, error)
+	KeywordSearchChunks(ctx context.Context, domainID string, q RetrievalQuery) ([]ChunkMatch, error)
 }
 
-// RetrievalService provides user-scoped retrieval business logic.
+// RetrievalService provides domain-scoped retrieval business logic.
 type RetrievalService interface {
-	Retrieve(ctx context.Context, userID string, q RetrievalQuery) (RetrievalResult, error)
+	Retrieve(ctx context.Context, domainID string, q RetrievalQuery) (RetrievalResult, error)
 }

--- a/internal/embedder/domain/source.go
+++ b/internal/embedder/domain/source.go
@@ -134,7 +134,9 @@ const (
 // The model is intentionally open to additional source types.
 type Source struct {
 	ID string
-	// UserID scopes this source to a single authenticated user.
+	// DomainID scopes this source to a domain (workspace); all domain members share it.
+	DomainID string
+	// UserID records the creating user for audit purposes.
 	UserID string
 	Type   SourceType
 	Name   string
@@ -248,30 +250,30 @@ type SourceSyncResult struct {
 // SourceRepository defines the persistence contract for sources.
 type SourceRepository interface {
 	Create(ctx context.Context, s Source) (Source, error)
-	GetByID(ctx context.Context, id, userID string) (Source, error)
-	List(ctx context.Context, userID string, p Page) (SourcePage, error)
-	Delete(ctx context.Context, id, userID string) error
+	GetByID(ctx context.Context, id, domainID string) (Source, error)
+	List(ctx context.Context, domainID string, p Page) (SourcePage, error)
+	Delete(ctx context.Context, id, domainID string) error
 	UpdateSyncResult(
 		ctx context.Context,
-		id, userID string,
+		id, domainID string,
 		status SourceStatus,
 		lastSyncAt time.Time,
 		lastSyncError *string,
 	) (Source, error)
-	UpdateConfig(ctx context.Context, id, userID string, config json.RawMessage) (Source, error)
+	UpdateConfig(ctx context.Context, id, domainID string, config json.RawMessage) (Source, error)
 }
 
 // SourceService defines the business-logic contract for sources.
 type SourceService interface {
 	Create(ctx context.Context, s Source) (Source, error)
-	GetByID(ctx context.Context, id, userID string) (Source, error)
-	List(ctx context.Context, userID string, p Page) (SourcePage, error)
-	Delete(ctx context.Context, id, userID string) error
-	UpdateGoogleDriveCredentials(ctx context.Context, id, userID string, update GoogleDriveCredentialUpdate) (Source, error)
-	UpdateGoogleDriveSelection(ctx context.Context, id, userID string, update GoogleDriveSelectionUpdate) (Source, error)
+	GetByID(ctx context.Context, id, domainID string) (Source, error)
+	List(ctx context.Context, domainID string, p Page) (SourcePage, error)
+	Delete(ctx context.Context, id, domainID string) error
+	UpdateGoogleDriveCredentials(ctx context.Context, id, domainID string, update GoogleDriveCredentialUpdate) (Source, error)
+	UpdateGoogleDriveSelection(ctx context.Context, id, domainID string, update GoogleDriveSelectionUpdate) (Source, error)
 }
 
 // SourceSyncService defines source-specific synchronization behavior.
 type SourceSyncService interface {
-	Sync(ctx context.Context, id, userID string) (SourceSyncResult, error)
+	Sync(ctx context.Context, id, domainID string) (SourceSyncResult, error)
 }

--- a/internal/embedder/domain/vector_retrieve.go
+++ b/internal/embedder/domain/vector_retrieve.go
@@ -16,5 +16,5 @@ type VectorChunk struct {
 
 // VectorRetrieveService retrieves relevant chunks via embedding similarity.
 type VectorRetrieveService interface {
-	Retrieve(ctx context.Context, userID, query string, recordIDs []string, topK int) ([]VectorChunk, error)
+	Retrieve(ctx context.Context, domainID, query string, recordIDs []string, topK int) ([]VectorChunk, error)
 }

--- a/internal/embedder/ingest/worker.go
+++ b/internal/embedder/ingest/worker.go
@@ -190,7 +190,7 @@ func (w *Worker) processRecord(ctx context.Context, rec domain.Record) {
 		chunkObjs[i] = postgres.Chunk{Content: c, Embedding: embeddings[i]}
 	}
 
-	if err := w.chunks.StoreChunks(ctx, rec.UserID, rec.ID, chunkObjs); err != nil {
+	if err := w.chunks.StoreChunks(ctx, rec.DomainID, rec.UserID, rec.ID, chunkObjs); err != nil {
 		logger.Error("ingest: store chunks", "err", err)
 		_ = w.records.UpdateStatus(ctx, rec.ID, domain.RecordStatusFailed, err.Error())
 		return
@@ -233,7 +233,7 @@ func (w *Worker) downloadContent(ctx context.Context, rec domain.Record) (string
 		return "", nil, fmt.Errorf("record %s is missing source_id", rec.ID)
 	}
 
-	src, err := w.sources.GetByID(ctx, rec.SourceID, rec.UserID)
+	src, err := w.sources.GetByID(ctx, rec.SourceID, rec.DomainID)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/embedder/postgres/chunks.go
+++ b/internal/embedder/postgres/chunks.go
@@ -30,7 +30,7 @@ type Chunk struct {
 
 // StoreChunks deletes existing chunks for recordID then inserts the new batch.
 // The embedding column is written as a pgvector literal: '[f1,f2,...]'.
-func (r *ChunksRepository) StoreChunks(ctx context.Context, userID, recordID string, chunks []Chunk) error {
+func (r *ChunksRepository) StoreChunks(ctx context.Context, domainID, userID, recordID string, chunks []Chunk) error {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -46,9 +46,9 @@ func (r *ChunksRepository) StoreChunks(ctx context.Context, userID, recordID str
 	for i, c := range chunks {
 		vec := float32SliceToPGVector(c.Embedding)
 		_, err := tx.Exec(ctx,
-			`INSERT INTO chunks (user_id, record_id, content, embedding, chunk_index)
-			 VALUES ($1, $2, $3, $4::vector, $5)`,
-			userID, recordID, c.Content, vec, i,
+			`INSERT INTO chunks (domain_id, user_id, record_id, content, embedding, chunk_index)
+			 VALUES ($1, $2, $3, $4, $5::vector, $6)`,
+			domainID, userID, recordID, c.Content, vec, i,
 		)
 		if err != nil {
 			return fmt.Errorf("insert chunk %d: %w", i, err)
@@ -69,20 +69,20 @@ type ChunkSearchResult struct {
 }
 
 // SearchChunks performs a cosine-distance vector similarity search over the
-// authenticated user's chunks.  If recordIDs is non-empty the search is
+// domain's chunks.  If recordIDs is non-empty the search is
 // scoped to those records only.  Results are ordered by ascending distance
 // (most similar first).
-func (r *ChunksRepository) SearchChunks(ctx context.Context, userID string, queryVec []float32, limit int, recordIDs []string) ([]ChunkSearchResult, error) {
+func (r *ChunksRepository) SearchChunks(ctx context.Context, domainID string, queryVec []float32, limit int, recordIDs []string) ([]ChunkSearchResult, error) {
 	vec := float32SliceToPGVector(queryVec)
 
 	var sb strings.Builder
-	args := []any{userID, vec, limit} // $1 $2 $3
+	args := []any{domainID, vec, limit} // $1 $2 $3
 
 	sb.WriteString(`
 		SELECT c.content, c.record_id, rec.name, COALESCE(rec.external_url, ''), c.chunk_index
 		FROM chunks c
 		JOIN records rec ON rec.id = c.record_id
-		WHERE c.user_id = $1
+		WHERE c.domain_id = $1
 		  AND c.embedding IS NOT NULL`)
 
 	if len(recordIDs) > 0 {

--- a/internal/embedder/postgres/chunks_search.go
+++ b/internal/embedder/postgres/chunks_search.go
@@ -14,7 +14,7 @@ import (
 
 func (r *ChunksRepository) KeywordSearchChunks(
 	ctx context.Context,
-	userID string,
+	domainID string,
 	q domain.RetrievalQuery,
 ) ([]domain.ChunkMatch, error) {
 	terms := searchTerms(q.Query)
@@ -22,11 +22,11 @@ func (r *ChunksRepository) KeywordSearchChunks(
 		return []domain.ChunkMatch{}, nil
 	}
 
-	args := []any{userID}
+	args := []any{domainID}
 	next := 2
 
 	var where []string
-	where = append(where, "c.user_id = $1", "r.user_id = $1", "r.status = 'indexed'")
+	where = append(where, "c.domain_id = $1", "r.domain_id = $1", "r.status = 'indexed'")
 
 	if len(q.RecordIDs) > 0 {
 		placeholders := make([]string, 0, len(q.RecordIDs))
@@ -140,7 +140,7 @@ func (r *ChunksRepository) KeywordSearchChunks(
 //	FROM vector_ranked v
 func (r *ChunksRepository) HybridSearchChunks(
 	ctx context.Context,
-	userID string,
+	domainID string,
 	queryVec []float32,
 	q domain.RetrievalQuery,
 ) ([]ChunkSearchResult, error) {
@@ -156,8 +156,8 @@ func (r *ChunksRepository) HybridSearchChunks(
 	terms := searchTerms(q.Query)
 	vec := float32SliceToPGVector(queryVec)
 
-	// $1=userID  $2=queryVec  $3=innerLimit
-	args := []any{userID, vec, innerLimit}
+	// $1=domainID  $2=queryVec  $3=innerLimit
+	args := []any{domainID, vec, innerLimit}
 	next := 4
 
 	// Optional record-ID filter shared by both CTEs.
@@ -184,7 +184,7 @@ func (r *ChunksRepository) HybridSearchChunks(
     SELECT c.id, ROW_NUMBER() OVER (ORDER BY c.embedding <-> $2::vector) AS rank
     FROM chunks c
     JOIN records rec ON rec.id = c.record_id
-    WHERE c.user_id = $1 AND c.embedding IS NOT NULL AND rec.status = 'indexed'`)
+    WHERE c.domain_id = $1 AND c.embedding IS NOT NULL AND rec.status = 'indexed'`)
 	sb.WriteString(recordIDFilter)
 	sb.WriteString(` LIMIT $3
 )`)
@@ -215,7 +215,7 @@ keyword_ranked AS (
                           websearch_to_tsquery('english', ` + queryPH + `)) AS fts_rank
         FROM chunks c
         JOIN records rec ON rec.id = c.record_id
-        WHERE c.user_id = $1
+        WHERE c.domain_id = $1
           AND rec.status = 'indexed'
           AND to_tsvector('english', c.content) @@ websearch_to_tsquery('english', ` + queryPH + `)`)
 		sb.WriteString(recordIDFilter)

--- a/internal/embedder/postgres/conversations.go
+++ b/internal/embedder/postgres/conversations.go
@@ -22,24 +22,28 @@ func NewConversationsRepository(pool *pgxpool.Pool) domain.ConversationRepositor
 	return &conversationsRepo{pool: pool}
 }
 
-func (r *conversationsRepo) Create(ctx context.Context, userID, title string) (domain.Conversation, error) {
+func (r *conversationsRepo) Create(ctx context.Context, domainID, userID, title string) (domain.Conversation, error) {
 	var c domain.Conversation
 	err := r.pool.QueryRow(ctx,
-		`INSERT INTO conversations (user_id, title) VALUES ($1, $2)
+		`INSERT INTO conversations (domain_id, user_id, title) VALUES ($1, $2, $3)
 		 RETURNING id, user_id, title, created_at, updated_at`,
-		userID, title,
+		domainID, userID, title,
 	).Scan(&c.ID, &c.UserID, &c.Title, &c.CreatedAt, &c.UpdatedAt)
+	c.DomainID = domainID
 	if err != nil {
 		return domain.Conversation{}, fmt.Errorf("create conversation: %w", err)
 	}
 	return c, nil
 }
 
-func (r *conversationsRepo) List(ctx context.Context, userID string) ([]domain.Conversation, error) {
+func (r *conversationsRepo) List(ctx context.Context, domainID string) ([]domain.Conversation, error) {
+	if domainID == "" {
+		return nil, nil
+	}
 	rows, err := r.pool.Query(ctx,
-		`SELECT id, user_id, title, created_at, updated_at
-		 FROM conversations WHERE user_id = $1 ORDER BY updated_at DESC`,
-		userID,
+		`SELECT id, domain_id, user_id, title, created_at, updated_at
+		 FROM conversations WHERE domain_id = $1 ORDER BY updated_at DESC`,
+		domainID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
@@ -49,7 +53,7 @@ func (r *conversationsRepo) List(ctx context.Context, userID string) ([]domain.C
 	var convs []domain.Conversation
 	for rows.Next() {
 		var c domain.Conversation
-		if err := rows.Scan(&c.ID, &c.UserID, &c.Title, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		if err := rows.Scan(&c.ID, &c.DomainID, &c.UserID, &c.Title, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan conversation: %w", err)
 		}
 		convs = append(convs, c)
@@ -57,13 +61,13 @@ func (r *conversationsRepo) List(ctx context.Context, userID string) ([]domain.C
 	return convs, rows.Err()
 }
 
-func (r *conversationsRepo) Get(ctx context.Context, id, userID string) (domain.Conversation, error) {
+func (r *conversationsRepo) Get(ctx context.Context, id, domainID string) (domain.Conversation, error) {
 	var c domain.Conversation
 	err := r.pool.QueryRow(ctx,
-		`SELECT id, user_id, title, created_at, updated_at
-		 FROM conversations WHERE id = $1 AND user_id = $2`,
-		id, userID,
-	).Scan(&c.ID, &c.UserID, &c.Title, &c.CreatedAt, &c.UpdatedAt)
+		`SELECT id, domain_id, user_id, title, created_at, updated_at
+		 FROM conversations WHERE id = $1 AND domain_id = $2`,
+		id, domainID,
+	).Scan(&c.ID, &c.DomainID, &c.UserID, &c.Title, &c.CreatedAt, &c.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.Conversation{}, domain.ErrNotFound
@@ -73,9 +77,9 @@ func (r *conversationsRepo) Get(ctx context.Context, id, userID string) (domain.
 	return c, nil
 }
 
-func (r *conversationsRepo) Delete(ctx context.Context, id, userID string) error {
+func (r *conversationsRepo) Delete(ctx context.Context, id, domainID string) error {
 	tag, err := r.pool.Exec(ctx,
-		`DELETE FROM conversations WHERE id = $1 AND user_id = $2`, id, userID,
+		`DELETE FROM conversations WHERE id = $1 AND domain_id = $2`, id, domainID,
 	)
 	if err != nil {
 		return fmt.Errorf("delete conversation: %w", err)
@@ -113,15 +117,15 @@ func (r *conversationsRepo) AppendMessages(ctx context.Context, conversationID s
 	return tx.Commit(ctx)
 }
 
-func (r *conversationsRepo) ListMessages(ctx context.Context, conversationID, userID string) ([]domain.ConversationMessage, error) {
-	// Verify ownership via join.
+func (r *conversationsRepo) ListMessages(ctx context.Context, conversationID, domainID string) ([]domain.ConversationMessage, error) {
+	// Verify domain ownership via join.
 	rows, err := r.pool.Query(ctx,
 		`SELECT m.id, m.conversation_id, m.role, m.content, m.created_at
 		 FROM conversation_messages m
 		 JOIN conversations c ON c.id = m.conversation_id
-		 WHERE m.conversation_id = $1 AND c.user_id = $2
+		 WHERE m.conversation_id = $1 AND c.domain_id = $2
 		 ORDER BY m.created_at`,
-		conversationID, userID,
+		conversationID, domainID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list messages: %w", err)

--- a/internal/embedder/postgres/records.go
+++ b/internal/embedder/postgres/records.go
@@ -24,9 +24,9 @@ func NewRecordsRepository(pool *pgxpool.Pool) domain.RecordRepository {
 	return &recordsRepo{pool: pool}
 }
 
-func (r *recordsRepo) GetByID(ctx context.Context, id, userID string) (domain.Record, error) {
+func (r *recordsRepo) GetByID(ctx context.Context, id, domainID string) (domain.Record, error) {
 	const q = `
-		SELECT r.id, r.user_id, r.source_id, r.name, r.format, r.status,
+		SELECT r.id, r.domain_id, r.user_id, r.source_id, r.name, r.format, r.status,
 		       r.external_id, r.external_url, r.external_ref, r.mime_type,
 		       r.description, r.chunk_count, r.size_bytes, r.page_count,
 		       r.source_version, r.source_modified_at, r.error,
@@ -34,9 +34,9 @@ func (r *recordsRepo) GetByID(ctx context.Context, id, userID string) (domain.Re
 		       s.id, s.name, s.source_type, s.status
 		FROM records r
 		LEFT JOIN sources s ON s.id = r.source_id
-		WHERE r.id = $1 AND r.user_id = $2`
+		WHERE r.id = $1 AND r.domain_id = $2`
 
-	row := r.pool.QueryRow(ctx, q, id, userID)
+	row := r.pool.QueryRow(ctx, q, id, domainID)
 	rec, err := scanRecord(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -49,12 +49,15 @@ func (r *recordsRepo) GetByID(ctx context.Context, id, userID string) (domain.Re
 
 func (r *recordsRepo) List(
 	ctx context.Context,
-	userID string,
+	domainID string,
 	f domain.RecordFilter,
 	p domain.Page,
 ) (domain.RecordPage, error) {
-	args := []any{userID}
-	conds := []string{"r.user_id = $1"}
+	if domainID == "" {
+		return domain.RecordPage{}, nil
+	}
+	args := []any{domainID}
+	conds := []string{"r.domain_id = $1"}
 
 	if f.SourceID != nil {
 		args = append(args, *f.SourceID)
@@ -77,7 +80,7 @@ func (r *recordsRepo) List(
 	}
 
 	q := fmt.Sprintf(`
-		SELECT r.id, r.user_id, r.source_id, r.name, r.format, r.status,
+		SELECT r.id, r.domain_id, r.user_id, r.source_id, r.name, r.format, r.status,
 		       r.external_id, r.external_url, r.external_ref, r.mime_type,
 		       r.description, r.chunk_count, r.size_bytes, r.page_count,
 		       r.source_version, r.source_modified_at, r.error,
@@ -147,7 +150,7 @@ func scanRecord(row interface {
 		linkStatus       pgtype.Text
 	)
 	if err := row.Scan(
-		&rec.ID, &rec.UserID, &sourceID, &rec.Name, &format, &status,
+		&rec.ID, &rec.DomainID, &rec.UserID, &sourceID, &rec.Name, &format, &status,
 		&externalID, &externalURL, &externalRef, &mimeType,
 		&description, &chunkCount, &sizeBytes, &pageCount,
 		&sourceVersion, &sourceModifiedAt, &recError,
@@ -215,11 +218,11 @@ func scanRecord(row interface {
 func (r *recordsRepo) Create(ctx context.Context, rec domain.Record) (domain.Record, error) {
 	const q = `
 		INSERT INTO records
-			(user_id, source_id, name, format, status,
+			(domain_id, user_id, source_id, name, format, status,
 			 external_id, external_url, external_ref, mime_type,
 			 source_version, source_modified_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-		RETURNING id, user_id, source_id, name, format, status,
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		RETURNING id, domain_id, user_id, source_id, name, format, status,
 		          external_id, external_url, external_ref, mime_type,
 		          description, chunk_count, size_bytes, page_count,
 		          source_version, source_modified_at, error,
@@ -232,7 +235,7 @@ func (r *recordsRepo) Create(ctx context.Context, rec domain.Record) (domain.Rec
 	}
 
 	row := r.pool.QueryRow(ctx, q,
-		rec.UserID, rec.SourceID, rec.Name, string(rec.Format), string(rec.Status),
+		rec.DomainID, rec.UserID, rec.SourceID, rec.Name, string(rec.Format), string(rec.Status),
 		rec.ExternalID, rec.ExternalURL, rec.ExternalRef, rec.MimeType,
 		rec.SourceVersion, sourceModifiedAt,
 	)
@@ -248,7 +251,7 @@ func (r *recordsRepo) Create(ctx context.Context, rec domain.Record) (domain.Rec
 
 func (r *recordsRepo) ListQueued(ctx context.Context, limit int) ([]domain.Record, error) {
 	const q = `
-		SELECT r.id, r.user_id, r.source_id, r.name, r.format, r.status,
+		SELECT r.id, r.domain_id, r.user_id, r.source_id, r.name, r.format, r.status,
 		       r.external_id, r.external_url, r.external_ref, r.mime_type,
 		       r.description, r.chunk_count, r.size_bytes, r.page_count,
 		       r.source_version, r.source_modified_at, r.error,
@@ -315,7 +318,7 @@ func (r *recordsRepo) UpsertFromSource(ctx context.Context, rec domain.Record) (
 	defer tx.Rollback(ctx)
 
 	const selectQ = `
-		SELECT r.id, r.user_id, r.source_id, r.name, r.format, r.status,
+		SELECT r.id, r.domain_id, r.user_id, r.source_id, r.name, r.format, r.status,
 		       r.external_id, r.external_url, r.external_ref, r.mime_type,
 		       r.description, r.chunk_count, r.size_bytes, r.page_count,
 		       r.source_version, r.source_modified_at, r.error,
@@ -323,10 +326,10 @@ func (r *recordsRepo) UpsertFromSource(ctx context.Context, rec domain.Record) (
 		       s.id, s.name, s.source_type, s.status
 		FROM records r
 		LEFT JOIN sources s ON s.id = r.source_id
-		WHERE r.user_id = $1 AND r.source_id = $2 AND r.external_id = $3
+		WHERE r.domain_id = $1 AND r.source_id = $2 AND r.external_id = $3
 		FOR UPDATE OF r`
 
-	existing, err := scanRecord(tx.QueryRow(ctx, selectQ, rec.UserID, rec.SourceID, rec.ExternalID))
+	existing, err := scanRecord(tx.QueryRow(ctx, selectQ, rec.DomainID, rec.SourceID, rec.ExternalID))
 	switch {
 	case err == nil:
 	case errors.Is(err, pgx.ErrNoRows):
@@ -368,11 +371,11 @@ func (r *recordsRepo) UpsertFromSource(ctx context.Context, rec domain.Record) (
 func (r *recordsRepo) createInTx(ctx context.Context, tx pgx.Tx, rec domain.Record) (domain.Record, error) {
 	const q = `
 		INSERT INTO records
-			(user_id, source_id, name, format, status,
+			(domain_id, user_id, source_id, name, format, status,
 			 external_id, external_url, external_ref, mime_type,
 			 source_version, source_modified_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-		RETURNING id, user_id, source_id, name, format, status,
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		RETURNING id, domain_id, user_id, source_id, name, format, status,
 		          external_id, external_url, external_ref, mime_type,
 		          description, chunk_count, size_bytes, page_count,
 		          source_version, source_modified_at, error,
@@ -385,7 +388,7 @@ func (r *recordsRepo) createInTx(ctx context.Context, tx pgx.Tx, rec domain.Reco
 	}
 
 	created, err := scanRecord(tx.QueryRow(ctx, q,
-		rec.UserID, rec.SourceID, rec.Name, string(rec.Format), string(rec.Status),
+		rec.DomainID, rec.UserID, rec.SourceID, rec.Name, string(rec.Format), string(rec.Status),
 		rec.ExternalID, rec.ExternalURL, rec.ExternalRef, rec.MimeType,
 		rec.SourceVersion, sourceModifiedAt,
 	))
@@ -426,7 +429,7 @@ func (r *recordsRepo) updateFromSourceInTx(
 		    page_count = $11,
 		    updated_at = now()
 		WHERE id = $12
-		RETURNING id, user_id, source_id, name, format, status,
+		RETURNING id, domain_id, user_id, source_id, name, format, status,
 		          external_id, external_url, external_ref, mime_type,
 		          description, chunk_count, size_bytes, page_count,
 		          source_version, source_modified_at, error,
@@ -475,7 +478,7 @@ func existingOrQueuedStatus(requeue bool, current domain.RecordStatus) domain.Re
 
 func (r *recordsRepo) DeleteBySourceExternalIDs(
 	ctx context.Context,
-	userID, sourceID string,
+	domainID, sourceID string,
 	externalIDs []string,
 ) (int, error) {
 	if len(externalIDs) == 0 {
@@ -501,8 +504,8 @@ func (r *recordsRepo) DeleteBySourceExternalIDs(
 
 	tag, err := r.pool.Exec(ctx,
 		`DELETE FROM records
-		 WHERE user_id = $1 AND source_id = $2 AND external_id = ANY($3)`,
-		userID, sourceID, uniq,
+		 WHERE domain_id = $1 AND source_id = $2 AND external_id = ANY($3)`,
+		domainID, sourceID, uniq,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("delete records by source external IDs: %w", err)
@@ -511,9 +514,9 @@ func (r *recordsRepo) DeleteBySourceExternalIDs(
 	return int(tag.RowsAffected()), nil
 }
 
-func (r *recordsRepo) Delete(ctx context.Context, id, userID string) error {
+func (r *recordsRepo) Delete(ctx context.Context, id, domainID string) error {
 	tag, err := r.pool.Exec(ctx,
-		`DELETE FROM records WHERE id = $1 AND user_id = $2`, id, userID,
+		`DELETE FROM records WHERE id = $1 AND domain_id = $2`, id, domainID,
 	)
 	if err != nil {
 		return fmt.Errorf("delete record: %w", err)

--- a/internal/embedder/postgres/sources.go
+++ b/internal/embedder/postgres/sources.go
@@ -32,14 +32,14 @@ func (r *sourcesRepo) Create(ctx context.Context, s domain.Source) (domain.Sourc
 	}
 
 	const q = `
-		INSERT INTO sources (user_id, source_type, name, config, status, sync_enabled, auto_sync_interval)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO sources (domain_id, user_id, source_type, name, config, status, sync_enabled, auto_sync_interval)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id, created_at, updated_at`
 
 	var id string
 	var createdAt, updatedAt time.Time
 	err := r.pool.QueryRow(ctx, q,
-		s.UserID, string(s.Type), s.Name, []byte(cfg),
+		s.DomainID, s.UserID, string(s.Type), s.Name, []byte(cfg),
 		string(s.Status), s.SyncEnabled, s.AutoSyncInterval,
 	).Scan(&id, &createdAt, &updatedAt)
 	if err != nil {
@@ -55,16 +55,16 @@ func (r *sourcesRepo) Create(ctx context.Context, s domain.Source) (domain.Sourc
 	return s, nil
 }
 
-func (r *sourcesRepo) GetByID(ctx context.Context, id, userID string) (domain.Source, error) {
+func (r *sourcesRepo) GetByID(ctx context.Context, id, domainID string) (domain.Source, error) {
 	const q = `
-		SELECT id, user_id, source_type, name, config, status,
+		SELECT id, domain_id, user_id, source_type, name, config, status,
 		       sync_enabled, auto_sync_interval,
 		       last_sync_at, last_sync_error, next_sync_at,
 		       created_at, updated_at
 		FROM sources
-		WHERE id = $1 AND user_id = $2`
+		WHERE id = $1 AND domain_id = $2`
 
-	row := r.pool.QueryRow(ctx, q, id, userID)
+	row := r.pool.QueryRow(ctx, q, id, domainID)
 	s, err := scanSource(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -75,14 +75,17 @@ func (r *sourcesRepo) GetByID(ctx context.Context, id, userID string) (domain.So
 	return s, nil
 }
 
-func (r *sourcesRepo) List(ctx context.Context, userID string, p domain.Page) (domain.SourcePage, error) {
+func (r *sourcesRepo) List(ctx context.Context, domainID string, p domain.Page) (domain.SourcePage, error) {
+	if domainID == "" {
+		return domain.SourcePage{}, nil
+	}
 	const q = `
-		SELECT id, user_id, source_type, name, config, status,
+		SELECT id, domain_id, user_id, source_type, name, config, status,
 		       sync_enabled, auto_sync_interval,
 		       last_sync_at, last_sync_error, next_sync_at,
 		       created_at, updated_at
 		FROM sources
-		WHERE user_id = $1
+		WHERE domain_id = $1
 		ORDER BY created_at DESC
 		LIMIT $2 OFFSET $3`
 
@@ -91,7 +94,7 @@ func (r *sourcesRepo) List(ctx context.Context, userID string, p domain.Page) (d
 		limit = 20
 	}
 
-	rows, err := r.pool.Query(ctx, q, userID, limit, p.Offset)
+	rows, err := r.pool.Query(ctx, q, domainID, limit, p.Offset)
 	if err != nil {
 		return domain.SourcePage{}, fmt.Errorf("list sources: %w", err)
 	}
@@ -111,7 +114,7 @@ func (r *sourcesRepo) List(ctx context.Context, userID string, p domain.Page) (d
 
 	var total uint64
 	if err := r.pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM sources WHERE user_id = $1`, userID,
+		`SELECT COUNT(*) FROM sources WHERE domain_id = $1`, domainID,
 	).Scan(&total); err != nil {
 		return domain.SourcePage{}, fmt.Errorf("count sources: %w", err)
 	}
@@ -119,9 +122,9 @@ func (r *sourcesRepo) List(ctx context.Context, userID string, p domain.Page) (d
 	return domain.SourcePage{Sources: sources, Total: total}, nil
 }
 
-func (r *sourcesRepo) Delete(ctx context.Context, id, userID string) error {
+func (r *sourcesRepo) Delete(ctx context.Context, id, domainID string) error {
 	tag, err := r.pool.Exec(ctx,
-		`DELETE FROM sources WHERE id = $1 AND user_id = $2`, id, userID)
+		`DELETE FROM sources WHERE id = $1 AND domain_id = $2`, id, domainID)
 	if err != nil {
 		return fmt.Errorf("delete source: %w", err)
 	}
@@ -133,7 +136,7 @@ func (r *sourcesRepo) Delete(ctx context.Context, id, userID string) error {
 
 func (r *sourcesRepo) UpdateSyncResult(
 	ctx context.Context,
-	id, userID string,
+	id, domainID string,
 	status domain.SourceStatus,
 	lastSyncAt time.Time,
 	lastSyncError *string,
@@ -144,8 +147,8 @@ func (r *sourcesRepo) UpdateSyncResult(
 		    last_sync_at = $2,
 		    last_sync_error = $3,
 		    updated_at = now()
-		WHERE id = $4 AND user_id = $5
-		RETURNING id, user_id, source_type, name, config, status,
+		WHERE id = $4 AND domain_id = $5
+		RETURNING id, domain_id, user_id, source_type, name, config, status,
 		          sync_enabled, auto_sync_interval,
 		          last_sync_at, last_sync_error, next_sync_at,
 		          created_at, updated_at`
@@ -155,7 +158,7 @@ func (r *sourcesRepo) UpdateSyncResult(
 		errMsg = pgtype.Text{String: *lastSyncError, Valid: true}
 	}
 
-	row := r.pool.QueryRow(ctx, q, string(status), lastSyncAt, errMsg, id, userID)
+	row := r.pool.QueryRow(ctx, q, string(status), lastSyncAt, errMsg, id, domainID)
 	src, err := scanSource(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -168,7 +171,7 @@ func (r *sourcesRepo) UpdateSyncResult(
 
 func (r *sourcesRepo) UpdateConfig(
 	ctx context.Context,
-	id, userID string,
+	id, domainID string,
 	config json.RawMessage,
 ) (domain.Source, error) {
 	const q = `
@@ -177,13 +180,13 @@ func (r *sourcesRepo) UpdateConfig(
 		    status = $2,
 		    last_sync_error = NULL,
 		    updated_at = now()
-		WHERE id = $3 AND user_id = $4
-		RETURNING id, user_id, source_type, name, config, status,
+		WHERE id = $3 AND domain_id = $4
+		RETURNING id, domain_id, user_id, source_type, name, config, status,
 		          sync_enabled, auto_sync_interval,
 		          last_sync_at, last_sync_error, next_sync_at,
 		          created_at, updated_at`
 
-	row := r.pool.QueryRow(ctx, q, []byte(config), string(domain.SourceStatusActive), id, userID)
+	row := r.pool.QueryRow(ctx, q, []byte(config), string(domain.SourceStatusActive), id, domainID)
 	src, err := scanSource(row)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -209,7 +212,7 @@ func scanSource(row interface {
 		nextSyncAt    pgtype.Timestamptz
 	)
 	if err := row.Scan(
-		&s.ID, &s.UserID, &sourceType, &s.Name, &config, &status,
+		&s.ID, &s.DomainID, &s.UserID, &sourceType, &s.Name, &config, &status,
 		&s.SyncEnabled, &s.AutoSyncInterval,
 		&lastSyncAt, &lastSyncError, &nextSyncAt,
 		&s.CreatedAt, &s.UpdatedAt,

--- a/internal/embedder/service/chat.go
+++ b/internal/embedder/service/chat.go
@@ -29,7 +29,7 @@ func NewChatService(retrieve domain.VectorRetrieveService, llmClient llm.Client,
 	return &chatService{retrieve: retrieve, llm: llmClient, reranker: reranker, topK: topK}
 }
 
-func (s *chatService) Chat(ctx context.Context, userID string, messages []domain.ChatMessage, recordIDs []string) (<-chan domain.ChatEvent, error) {
+func (s *chatService) Chat(ctx context.Context, domainID string, messages []domain.ChatMessage, recordIDs []string) (<-chan domain.ChatEvent, error) {
 	query := ""
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].Role == "user" {
@@ -44,7 +44,7 @@ func (s *chatService) Chat(ctx context.Context, userID string, messages []domain
 
 	if query != "" {
 		var err error
-		chunks, err = s.retrieve.Retrieve(ctx, userID, query, recordIDs, s.topK)
+		chunks, err = s.retrieve.Retrieve(ctx, domainID, query, recordIDs, s.topK)
 		if err != nil {
 			retrievalWarning = "Retrieval failed: " + err.Error() + " — answering without document context."
 			chunks = nil
@@ -98,7 +98,7 @@ func (s *chatService) Chat(ctx context.Context, userID string, messages []domain
 	llmMessages := make([]llm.Message, 0, len(messages)+1)
 	llmMessages = append(llmMessages, llm.Message{
 		Role:    "system",
-		Content: "You are a helpful assistant. When document excerpts are provided, answer based on them.",
+		Content: "You are a helpful, knowledgeable assistant. When document excerpts are provided, use them as your primary source and cite them, but also use your general knowledge to give complete, thorough answers.",
 	})
 	if contextBlock.Len() > 0 {
 		// RAG mode: only send the last user message augmented with context.
@@ -108,8 +108,8 @@ func (s *chatService) Chat(ctx context.Context, userID string, messages []domain
 			if messages[i].Role == "user" {
 				llmMessages = append(llmMessages, llm.Message{
 					Role: "user",
-					Content: "Use the following document excerpts to answer the question. " +
-						"Answer based on the excerpts — do not use outside knowledge.\n\n" +
+					Content: "Use the following document excerpts to inform your answer. " +
+						"Cite relevant excerpts, then elaborate with a complete and thorough explanation.\n\n" +
 						"EXCERPTS:\n" + contextBlock.String() +
 						"QUESTION: " + messages[i].Content,
 				})

--- a/internal/embedder/service/records.go
+++ b/internal/embedder/service/records.go
@@ -29,25 +29,25 @@ func (s *recordsService) Create(ctx context.Context, r domain.Record) (domain.Re
 	return s.repo.Create(ctx, r)
 }
 
-func (s *recordsService) GetByID(ctx context.Context, id, userID string) (domain.Record, error) {
-	return s.repo.GetByID(ctx, id, userID)
+func (s *recordsService) GetByID(ctx context.Context, id, domainID string) (domain.Record, error) {
+	return s.repo.GetByID(ctx, id, domainID)
 }
 
 func (s *recordsService) List(
 	ctx context.Context,
-	userID string,
+	domainID string,
 	f domain.RecordFilter,
 	p domain.Page,
 ) (domain.RecordPage, error) {
-	return s.repo.List(ctx, userID, f, p)
+	return s.repo.List(ctx, domainID, f, p)
 }
 
-func (s *recordsService) Delete(ctx context.Context, id, userID string) error {
-	return s.repo.Delete(ctx, id, userID)
+func (s *recordsService) Delete(ctx context.Context, id, domainID string) error {
+	return s.repo.Delete(ctx, id, domainID)
 }
 
-func (s *recordsService) RetryIngest(ctx context.Context, id, userID string) error {
-	if _, err := s.repo.GetByID(ctx, id, userID); err != nil {
+func (s *recordsService) RetryIngest(ctx context.Context, id, domainID string) error {
+	if _, err := s.repo.GetByID(ctx, id, domainID); err != nil {
 		return err
 	}
 	return s.repo.UpdateStatus(ctx, id, domain.RecordStatusQueued, "")

--- a/internal/embedder/service/retrieval.go
+++ b/internal/embedder/service/retrieval.go
@@ -22,11 +22,11 @@ func NewRetrievalService(repo domain.RetrievalRepository) domain.RetrievalServic
 
 func (s *retrievalService) Retrieve(
 	ctx context.Context,
-	userID string,
+	domainID string,
 	q domain.RetrievalQuery,
 ) (domain.RetrievalResult, error) {
-	if strings.TrimSpace(userID) == "" {
-		return domain.RetrievalResult{}, fmt.Errorf("user_id is required")
+	if strings.TrimSpace(domainID) == "" {
+		return domain.RetrievalResult{}, fmt.Errorf("domain_id is required")
 	}
 	if strings.TrimSpace(q.Query) == "" {
 		return domain.RetrievalResult{}, fmt.Errorf("query is required")
@@ -38,7 +38,7 @@ func (s *retrievalService) Retrieve(
 		q.TopK = 20
 	}
 
-	matches, err := s.repo.KeywordSearchChunks(ctx, userID, q)
+	matches, err := s.repo.KeywordSearchChunks(ctx, domainID, q)
 	if err != nil {
 		return domain.RetrievalResult{}, err
 	}

--- a/internal/embedder/service/source_sync.go
+++ b/internal/embedder/service/source_sync.go
@@ -34,8 +34,8 @@ func NewSourceSyncService(
 	}
 }
 
-func (s *sourceSyncService) Sync(ctx context.Context, id, userID string) (res domain.SourceSyncResult, err error) {
-	src, err := s.sources.GetByID(ctx, id, userID)
+func (s *sourceSyncService) Sync(ctx context.Context, id, domainID string) (res domain.SourceSyncResult, err error) {
+	src, err := s.sources.GetByID(ctx, id, domainID)
 	if err != nil {
 		return domain.SourceSyncResult{}, err
 	}
@@ -64,10 +64,10 @@ func (s *sourceSyncService) Sync(ctx context.Context, id, userID string) (res do
 	}()
 
 	now := time.Now().UTC()
-	files, err := provider.ListFiles(ctx, userID, src)
+	files, err := provider.ListFiles(ctx, src.UserID, src)
 	if err != nil {
 		msg := err.Error()
-		updatedSource, markErr := s.sources.UpdateSyncResult(ctx, src.ID, userID, domain.SourceStatusError, now, &msg)
+		updatedSource, markErr := s.sources.UpdateSyncResult(ctx, src.ID, src.DomainID, domain.SourceStatusError, now, &msg)
 		if markErr == nil {
 			src = updatedSource
 		}
@@ -88,7 +88,8 @@ func (s *sourceSyncService) Sync(ctx context.Context, id, userID string) (res do
 		liveExternalIDs[externalID] = struct{}{}
 
 		upsert, err := s.records.UpsertFromSource(ctx, domain.Record{
-			UserID:           userID,
+			DomainID:         src.DomainID,
+			UserID:           src.UserID,
 			SourceID:         src.ID,
 			Name:             file.Name,
 			Format:           DetectRecordFormat(file.Name, file.MimeType),
@@ -102,7 +103,7 @@ func (s *sourceSyncService) Sync(ctx context.Context, id, userID string) (res do
 		})
 		if err != nil {
 			msg := err.Error()
-			updatedSource, markErr := s.sources.UpdateSyncResult(ctx, src.ID, userID, domain.SourceStatusError, now, &msg)
+			updatedSource, markErr := s.sources.UpdateSyncResult(ctx, src.ID, src.DomainID, domain.SourceStatusError, now, &msg)
 			if markErr == nil {
 				src = updatedSource
 			}
@@ -121,19 +122,19 @@ func (s *sourceSyncService) Sync(ctx context.Context, id, userID string) (res do
 	}
 
 	if provider.PrunesStaleRecords() {
-		toDelete, err := s.resolveStaleSourceExternalIDs(ctx, userID, src.ID, liveExternalIDs)
+		toDelete, err := s.resolveStaleSourceExternalIDs(ctx, src.DomainID, src.ID, liveExternalIDs)
 		if err != nil {
 			msg := err.Error()
-			updatedSource, markErr := s.sources.UpdateSyncResult(ctx, src.ID, userID, domain.SourceStatusError, now, &msg)
+			updatedSource, markErr := s.sources.UpdateSyncResult(ctx, src.ID, src.DomainID, domain.SourceStatusError, now, &msg)
 			if markErr == nil {
 				src = updatedSource
 			}
 			return domain.SourceSyncResult{}, err
 		}
-		deleted, err := s.records.DeleteBySourceExternalIDs(ctx, userID, src.ID, toDelete)
+		deleted, err := s.records.DeleteBySourceExternalIDs(ctx, src.DomainID, src.ID, toDelete)
 		if err != nil {
 			msg := err.Error()
-			updatedSource, markErr := s.sources.UpdateSyncResult(ctx, src.ID, userID, domain.SourceStatusError, now, &msg)
+			updatedSource, markErr := s.sources.UpdateSyncResult(ctx, src.ID, src.DomainID, domain.SourceStatusError, now, &msg)
 			if markErr == nil {
 				src = updatedSource
 			}
@@ -142,7 +143,7 @@ func (s *sourceSyncService) Sync(ctx context.Context, id, userID string) (res do
 		result.Deleted = uint64(deleted)
 	}
 
-	updatedSource, updateErr := s.sources.UpdateSyncResult(ctx, src.ID, userID, domain.SourceStatusActive, now, nil)
+	updatedSource, updateErr := s.sources.UpdateSyncResult(ctx, src.ID, src.DomainID, domain.SourceStatusActive, now, nil)
 	if updateErr == nil {
 		result.Source = updatedSource
 	}
@@ -150,39 +151,9 @@ func (s *sourceSyncService) Sync(ctx context.Context, id, userID string) (res do
 	return result, nil
 }
 
-func recordFormatFromDriveFile(file ingest.DriveFile) domain.RecordFormat {
-	return DetectRecordFormat(file.Name, file.MimeType)
-}
-
-func filterDriveFilesBySelection(files []ingest.DriveFile, selectedIDs []string) []ingest.DriveFile {
-	if len(selectedIDs) == 0 {
-		return files
-	}
-
-	selected := make(map[string]struct{}, len(selectedIDs))
-	for _, id := range selectedIDs {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			continue
-		}
-		selected[id] = struct{}{}
-	}
-	if len(selected) == 0 {
-		return files
-	}
-
-	filtered := make([]ingest.DriveFile, 0, len(files))
-	for _, file := range files {
-		if _, ok := selected[file.ID]; ok {
-			filtered = append(filtered, file)
-		}
-	}
-	return filtered
-}
-
 func (s *sourceSyncService) resolveStaleSourceExternalIDs(
 	ctx context.Context,
-	userID, sourceID string,
+	domainID, sourceID string,
 	live map[string]struct{},
 ) ([]string, error) {
 	filter := domain.RecordFilter{SourceID: &sourceID}
@@ -191,7 +162,7 @@ func (s *sourceSyncService) resolveStaleSourceExternalIDs(
 
 	stale := make([]string, 0)
 	for {
-		page, err := s.records.List(ctx, userID, filter, domain.Page{
+		page, err := s.records.List(ctx, domainID, filter, domain.Page{
 			Offset: offset,
 			Limit:  pageLimit,
 		})

--- a/internal/embedder/service/source_sync.go
+++ b/internal/embedder/service/source_sync.go
@@ -151,6 +151,36 @@ func (s *sourceSyncService) Sync(ctx context.Context, id, domainID string) (res 
 	return result, nil
 }
 
+func recordFormatFromDriveFile(file ingest.DriveFile) domain.RecordFormat {
+	return DetectRecordFormat(file.Name, file.MimeType)
+}
+
+func filterDriveFilesBySelection(files []ingest.DriveFile, selectedIDs []string) []ingest.DriveFile {
+	if len(selectedIDs) == 0 {
+		return files
+	}
+
+	selected := make(map[string]struct{}, len(selectedIDs))
+	for _, id := range selectedIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		selected[id] = struct{}{}
+	}
+	if len(selected) == 0 {
+		return files
+	}
+
+	filtered := make([]ingest.DriveFile, 0, len(files))
+	for _, file := range files {
+		if _, ok := selected[file.ID]; ok {
+			filtered = append(filtered, file)
+		}
+	}
+	return filtered
+}
+
 func (s *sourceSyncService) resolveStaleSourceExternalIDs(
 	ctx context.Context,
 	domainID, sourceID string,

--- a/internal/embedder/service/sources.go
+++ b/internal/embedder/service/sources.go
@@ -25,6 +25,9 @@ func NewSourcesService(repo domain.SourceRepository) domain.SourceService {
 }
 
 func (s *sourcesService) Create(ctx context.Context, src domain.Source) (domain.Source, error) {
+	if src.DomainID == "" {
+		return domain.Source{}, fmt.Errorf("domain_id is required")
+	}
 	if src.UserID == "" {
 		return domain.Source{}, fmt.Errorf("user_id is required")
 	}
@@ -76,24 +79,24 @@ func (s *sourcesService) Create(ctx context.Context, src domain.Source) (domain.
 	return s.repo.Create(ctx, src)
 }
 
-func (s *sourcesService) GetByID(ctx context.Context, id, userID string) (domain.Source, error) {
-	return s.repo.GetByID(ctx, id, userID)
+func (s *sourcesService) GetByID(ctx context.Context, id, domainID string) (domain.Source, error) {
+	return s.repo.GetByID(ctx, id, domainID)
 }
 
-func (s *sourcesService) List(ctx context.Context, userID string, p domain.Page) (domain.SourcePage, error) {
-	return s.repo.List(ctx, userID, p)
+func (s *sourcesService) List(ctx context.Context, domainID string, p domain.Page) (domain.SourcePage, error) {
+	return s.repo.List(ctx, domainID, p)
 }
 
-func (s *sourcesService) Delete(ctx context.Context, id, userID string) error {
-	return s.repo.Delete(ctx, id, userID)
+func (s *sourcesService) Delete(ctx context.Context, id, domainID string) error {
+	return s.repo.Delete(ctx, id, domainID)
 }
 
 func (s *sourcesService) UpdateGoogleDriveCredentials(
 	ctx context.Context,
-	id, userID string,
+	id, domainID string,
 	update domain.GoogleDriveCredentialUpdate,
 ) (domain.Source, error) {
-	src, err := s.repo.GetByID(ctx, id, userID)
+	src, err := s.repo.GetByID(ctx, id, domainID)
 	if err != nil {
 		return domain.Source{}, err
 	}
@@ -133,15 +136,15 @@ func (s *sourcesService) UpdateGoogleDriveCredentials(
 	if err != nil {
 		return domain.Source{}, fmt.Errorf("encode source config: %w", err)
 	}
-	return s.repo.UpdateConfig(ctx, id, userID, raw)
+	return s.repo.UpdateConfig(ctx, id, domainID, raw)
 }
 
 func (s *sourcesService) UpdateGoogleDriveSelection(
 	ctx context.Context,
-	id, userID string,
+	id, domainID string,
 	update domain.GoogleDriveSelectionUpdate,
 ) (domain.Source, error) {
-	src, err := s.repo.GetByID(ctx, id, userID)
+	src, err := s.repo.GetByID(ctx, id, domainID)
 	if err != nil {
 		return domain.Source{}, err
 	}
@@ -163,7 +166,7 @@ func (s *sourcesService) UpdateGoogleDriveSelection(
 	if err != nil {
 		return domain.Source{}, fmt.Errorf("encode source config: %w", err)
 	}
-	return s.repo.UpdateConfig(ctx, id, userID, raw)
+	return s.repo.UpdateConfig(ctx, id, domainID, raw)
 }
 
 func sanitizeGoogleDriveConfig(raw json.RawMessage) (json.RawMessage, error) {

--- a/internal/embedder/service/vector_retrieve.go
+++ b/internal/embedder/service/vector_retrieve.go
@@ -22,7 +22,7 @@ func NewVectorRetrieveService(chunks *postgres.ChunksRepository, embedder *embed
 	return &vectorRetrieveService{chunks: chunks, embedder: embedder}
 }
 
-func (s *vectorRetrieveService) Retrieve(ctx context.Context, userID, query string, recordIDs []string, topK int) ([]domain.VectorChunk, error) {
+func (s *vectorRetrieveService) Retrieve(ctx context.Context, domainID, query string, recordIDs []string, topK int) ([]domain.VectorChunk, error) {
 	if query == "" {
 		return nil, fmt.Errorf("query is required")
 	}
@@ -40,7 +40,7 @@ func (s *vectorRetrieveService) Retrieve(ctx context.Context, userID, query stri
 		return nil, fmt.Errorf("embed query: %w", err)
 	}
 
-	results, err := s.chunks.HybridSearchChunks(ctx, userID, vecs[0], domain.RetrievalQuery{
+	results, err := s.chunks.HybridSearchChunks(ctx, domainID, vecs[0], domain.RetrievalQuery{
 		Query:     query,
 		RecordIDs: recordIDs,
 		TopK:      topK,

--- a/proxy/api/transport.go
+++ b/proxy/api/transport.go
@@ -268,7 +268,7 @@ func prepareProxyRequest(req *http.Request, target *url.URL, rule *router.RouteR
 			// Pass domain ID to downstream services (e.g., guardrails)
 			// so they can route LLM calls back through the proxy
 			// with the correct domain path prefix.
-			req.Header.Set("X-Domain-ID", domainID)
+			req.Header.Set("X-Domain-Id", domainID)
 		}
 	}
 

--- a/ui/src/layouts/AppLayout.tsx
+++ b/ui/src/layouts/AppLayout.tsx
@@ -46,16 +46,34 @@ export default function AppLayout() {
     localStorage.removeItem(CONV_KEY)
   }, [])
 
+  const domainID = activeDomain?.id ?? ''
+
   useEffect(() => {
-    if (!tokens?.accessToken) return
+    // Clear stale data from the previous domain immediately so pages never
+    // briefly show records that belong to a different domain.
+    setRecords([])
+    setDriveSources([])
+    setConversations([])
+
+    if (!tokens?.accessToken || !domainID) return
+
+    let cancelled = false
     const token = tokens.accessToken
-    Promise.all([listRecords(token), listSources(token)])
-      .then(([recs, srcs]) => { setRecords(recs); setDriveSources(srcs) })
+
+    Promise.all([listRecords(token, domainID), listSources(token, domainID)])
+      .then(([recs, srcs]) => {
+        if (cancelled) return
+        setRecords(recs)
+        setDriveSources(srcs)
+      })
       .catch((err: unknown) => console.error('failed to load records/sources:', err))
-    listConversations(token)
-      .then(convs => setConversations(convs))
+
+    listConversations(token, domainID)
+      .then(convs => { if (!cancelled) setConversations(convs) })
       .catch((err: unknown) => console.error('failed to load conversations:', err))
-  }, [tokens?.accessToken])
+
+    return () => { cancelled = true }
+  }, [tokens?.accessToken, domainID])
 
   useEffect(() => {
     if (persistTimer.current !== null) clearTimeout(persistTimer.current)

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -28,7 +28,7 @@ export interface ChatEvent {
 // listRecords fetches the domain's records from the embedder API.
 export async function listRecords(token: string, domainID: string): Promise<AppRecord[]> {
   const headers: Record<string, string> = { Authorization: `Bearer ${token}` }
-  if (domainID) headers['X-Domain-ID'] = domainID
+  if (domainID) headers['X-Domain-Id'] = domainID
   const res = await fetch('/api/v1/records', { headers })
   if (!res.ok) throw new Error(`listRecords: ${res.status}`)
   const data = await res.json()
@@ -50,7 +50,7 @@ export function streamChat(
     'Content-Type': 'application/json',
     Authorization: `Bearer ${token}`,
   }
-  if (domainID) headers['X-Domain-ID'] = domainID
+  if (domainID) headers['X-Domain-Id'] = domainID
   return fetch('/api/v1/chat', {
     method: 'POST',
     headers,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -25,11 +25,11 @@ export interface ChatEvent {
   conversation_id?: string
 }
 
-// listRecords fetches the user's records from the embedder API.
-export async function listRecords(token: string): Promise<AppRecord[]> {
-  const res = await fetch('/api/v1/records', {
-    headers: { Authorization: `Bearer ${token}` },
-  })
+// listRecords fetches the domain's records from the embedder API.
+export async function listRecords(token: string, domainID: string): Promise<AppRecord[]> {
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}` }
+  if (domainID) headers['X-Domain-ID'] = domainID
+  const res = await fetch('/api/v1/records', { headers })
   if (!res.ok) throw new Error(`listRecords: ${res.status}`)
   const data = await res.json()
   return (data.records ?? []).map(toAppRecord)
@@ -39,18 +39,21 @@ export async function listRecords(token: string): Promise<AppRecord[]> {
 // for each parsed event.  Returns a cleanup function that aborts the stream.
 export function streamChat(
   token: string,
+  domainID: string,
   messages: ChatMessage[],
   recordIDs: string[],
   onEvent: (event: ChatEvent) => void,
   signal?: AbortSignal,
   conversationId?: string | null,
 ): Promise<void> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  }
+  if (domainID) headers['X-Domain-ID'] = domainID
   return fetch('/api/v1/chat', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
+    headers,
     body: JSON.stringify({ messages, record_ids: recordIDs, conversation_id: conversationId ?? undefined }),
     signal,
   }).then(async (res) => {

--- a/ui/src/lib/embedder/service.ts
+++ b/ui/src/lib/embedder/service.ts
@@ -337,6 +337,22 @@ async function readError(res: Response): Promise<string> {
   }
 }
 
+function domainInit(domainID: string, init?: RequestInit): RequestInit {
+  return {
+    ...init,
+    headers: {
+      ...(init?.headers ?? {}),
+      ...(domainID ? { 'X-Domain-ID': domainID } : {}),
+    },
+  }
+}
+
+function authHeaders(token: string, domainID: string): Record<string, string> {
+  const h: Record<string, string> = { Authorization: `Bearer ${token}` }
+  if (domainID) h['X-Domain-ID'] = domainID
+  return h
+}
+
 async function apiJSON<T>(path: string, token: string, init?: RequestInit): Promise<T> {
   const res = await fetch(buildURL(path), {
     ...init,
@@ -352,22 +368,22 @@ async function apiJSON<T>(path: string, token: string, init?: RequestInit): Prom
   return await res.json() as T
 }
 
-export async function listRecords(token: string): Promise<AppRecord[]> {
-  const data = await apiJSON<RecordListDTO>('/api/v1/records?limit=1000', token, { method: 'GET' })
+export async function listRecords(token: string, domainID: string): Promise<AppRecord[]> {
+  const data = await apiJSON<RecordListDTO>('/api/v1/records?limit=1000', token, domainInit(domainID, { method: 'GET' }))
   return data.records.map(mapRecord)
 }
 
-export async function listRecordsBySource(token: string, sourceID: string): Promise<AppRecord[]> {
-  const data = await apiJSON<RecordListDTO>(`/api/v1/sources/${sourceID}/records?limit=1000`, token, { method: 'GET' })
+export async function listRecordsBySource(token: string, domainID: string, sourceID: string): Promise<AppRecord[]> {
+  const data = await apiJSON<RecordListDTO>(`/api/v1/sources/${sourceID}/records?limit=1000`, token, domainInit(domainID, { method: 'GET' }))
   return data.records.map(mapRecord)
 }
 
-export async function listSources(token: string): Promise<DriveSource[]> {
-  const data = await apiJSON<SourceListDTO>('/api/v1/sources', token, { method: 'GET' })
+export async function listSources(token: string, domainID: string): Promise<DriveSource[]> {
+  const data = await apiJSON<SourceListDTO>('/api/v1/sources', token, domainInit(domainID, { method: 'GET' }))
   return data.sources.map(mapSource)
 }
 
-export async function createSource(token: string, source: DriveSourceDraft): Promise<DriveSource> {
+export async function createSource(token: string, domainID: string, source: DriveSourceDraft): Promise<DriveSource> {
   const config = source.sourceType === 'google_drive'
     ? {
       folder_id: source.folderLink ?? '',
@@ -386,7 +402,7 @@ export async function createSource(token: string, source: DriveSourceDraft): Pro
       config_ref: source.rcloneConfigRef ?? '',
     }
 
-  const created = await apiJSON<SourceDTO>('/api/v1/sources', token, {
+  const created = await apiJSON<SourceDTO>('/api/v1/sources', token, domainInit(domainID, {
     method: 'POST',
     body: JSON.stringify({
       source_type: source.sourceType,
@@ -395,7 +411,7 @@ export async function createSource(token: string, source: DriveSourceDraft): Pro
       auto_sync_interval: source.autoSyncInterval,
       config,
     }),
-  })
+  }))
 
   return mapSource(created)
 }
@@ -557,10 +573,10 @@ export interface SourceSyncResult {
   deleted: number
 }
 
-export async function syncSource(token: string, sourceID: string): Promise<SourceSyncResult> {
-  const data = await apiJSON<SourceSyncDTO>(`/api/v1/sources/${sourceID}/sync`, token, {
+export async function syncSource(token: string, domainID: string, sourceID: string): Promise<SourceSyncResult> {
+  const data = await apiJSON<SourceSyncDTO>(`/api/v1/sources/${sourceID}/sync`, token, domainInit(domainID, {
     method: 'POST',
-  })
+  }))
   return {
     source: mapSource(data.source),
     discovered: data.discovered,
@@ -573,44 +589,45 @@ export async function syncSource(token: string, sourceID: string): Promise<Sourc
 
 export async function updateGoogleSourceSelection(
   token: string,
+  domainID: string,
   sourceID: string,
   selectedFileIDs: string[],
   selectedFolderIDs: string[] = [],
 ): Promise<DriveSource> {
-  const updated = await apiJSON<SourceDTO>(`/api/v1/sources/${sourceID}/selection`, token, {
+  const updated = await apiJSON<SourceDTO>(`/api/v1/sources/${sourceID}/selection`, token, domainInit(domainID, {
     method: 'PUT',
     body: JSON.stringify({
       selected_file_ids: selectedFileIDs,
       selected_folder_ids: selectedFolderIDs,
     }),
-  })
+  }))
   return mapSource(updated)
 }
 
-export async function deleteSource(token: string, sourceID: string): Promise<void> {
+export async function deleteSource(token: string, domainID: string, sourceID: string): Promise<void> {
   const res = await fetch(buildURL(`/api/v1/sources/${sourceID}`), {
     method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders(token, domainID),
   })
   if (!res.ok) {
     throw new Error(await readError(res))
   }
 }
 
-export async function deleteRecord(token: string, recordID: string): Promise<void> {
+export async function deleteRecord(token: string, domainID: string, recordID: string): Promise<void> {
   const res = await fetch(buildURL(`/api/v1/records/${recordID}`), {
     method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders(token, domainID),
   })
   if (!res.ok) {
     throw new Error(await readError(res))
   }
 }
 
-export async function retryRecordIngest(token: string, recordID: string): Promise<void> {
+export async function retryRecordIngest(token: string, domainID: string, recordID: string): Promise<void> {
   const res = await fetch(buildURL(`/api/v1/records/${recordID}/retry`), {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders(token, domainID),
   })
   if (!res.ok) {
     throw new Error(await readError(res))
@@ -619,6 +636,7 @@ export async function retryRecordIngest(token: string, recordID: string): Promis
 
 export async function uploadRecordFile(
   token: string,
+  domainID: string,
   file: File,
   name?: string,
   sourceID?: string,
@@ -630,9 +648,7 @@ export async function uploadRecordFile(
 
   const res = await fetch(buildURL('/api/v1/records/upload'), {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+    headers: authHeaders(token, domainID),
     body: formData,
   })
   if (!res.ok) {
@@ -652,16 +668,17 @@ function mapConversation(dto: ConversationDTO): Conversation {
   }
 }
 
-export async function listConversations(token: string): Promise<Conversation[]> {
-  const data = await apiJSON<ConversationListDTO>('/api/v1/conversations', token, { method: 'GET' })
+export async function listConversations(token: string, domainID: string): Promise<Conversation[]> {
+  const data = await apiJSON<ConversationListDTO>('/api/v1/conversations', token, domainInit(domainID, { method: 'GET' }))
   return (data.conversations ?? []).map(mapConversation)
 }
 
 export async function getConversation(
   token: string,
+  domainID: string,
   id: string,
 ): Promise<{ conversation: Conversation; messages: ChatMessage[] }> {
-  const data = await apiJSON<ConversationDetailDTO>(`/api/v1/conversations/${id}`, token, { method: 'GET' })
+  const data = await apiJSON<ConversationDetailDTO>(`/api/v1/conversations/${id}`, token, domainInit(domainID, { method: 'GET' }))
   const messages: ChatMessage[] = (data.messages ?? []).map((m, i) => ({
     id: i,
     role: m.role as 'user' | 'assistant',
@@ -670,10 +687,10 @@ export async function getConversation(
   return { conversation: mapConversation(data.conversation), messages }
 }
 
-export async function deleteConversation(token: string, id: string): Promise<void> {
+export async function deleteConversation(token: string, domainID: string, id: string): Promise<void> {
   const res = await fetch(buildURL(`/api/v1/conversations/${id}`), {
     method: 'DELETE',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders(token, domainID),
   })
   if (!res.ok) {
     throw new Error(await readError(res))

--- a/ui/src/lib/platform/service.ts
+++ b/ui/src/lib/platform/service.ts
@@ -21,6 +21,18 @@ import type {
 
 export type { Domain, Invitation, User, MemberRoles, Journal }
 
+// The magistrala SDK throws plain objects { status, error } rather than Error
+// instances. This converts them so callers can use err.message normally.
+function sdkError(err: unknown): Error {
+  if (err instanceof Error) return err
+  if (err && typeof err === 'object' && 'error' in err) {
+    const e = err as { error: unknown; status?: unknown }
+    const msg = typeof e.error === 'string' ? e.error : JSON.stringify(e.error)
+    return new Error(msg || `request failed (${e.status ?? 'unknown'})`)
+  }
+  return new Error(String(err))
+}
+
 const sdk = new SDK({
   usersUrl: window.location.origin,
   domainsUrl: window.location.origin,
@@ -30,22 +42,39 @@ const sdk = new SDK({
 // ── Domains ────────────────────────────────────────────────────────────────
 
 export async function listDomains(token: string): Promise<Domain[]> {
-  const page: DomainsPage = await sdk.Domains.Domains({ limit: 100, offset: 0 } as PageMetadata, token)
-  return page.domains ?? []
+  try {
+    const page: DomainsPage = await sdk.Domains.Domains({ limit: 100, offset: 0 } as PageMetadata, token)
+    return page.domains ?? []
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function listUserDomains(userID: string, token: string): Promise<Domain[]> {
-  const page: DomainsPage = await sdk.Domains.ListUserDomains(userID, { limit: 100, offset: 0 } as PageMetadata, token)
-  return page.domains ?? []
+  try {
+    const page: DomainsPage = await sdk.Domains.ListUserDomains(userID, { limit: 100, offset: 0 } as PageMetadata, token)
+    return page.domains ?? []
+  } catch (e) { throw sdkError(e) }
 }
 
-export async function createDomain(name: string, token: string): Promise<Domain> {
-  const route = name.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
-  return sdk.Domains.CreateDomain({ name, route } as Domain, token)
+export function toRoute(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
+}
+
+export async function createDomain(name: string, route: string, token: string): Promise<Domain> {
+  try {
+    return await sdk.Domains.CreateDomain({ name, route } as Domain, token)
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function getDomain(domainID: string, token: string): Promise<Domain> {
-  return sdk.Domains.Domain(domainID, token)
+  try {
+    return await sdk.Domains.Domain(domainID, token)
+  } catch (e) { throw sdkError(e) }
+}
+
+export async function deleteDomain(domainID: string, token: string): Promise<void> {
+  try {
+    await sdk.Domains.DisableDomain(domainID, token)
+  } catch (e) { throw sdkError(e) }
 }
 
 // ── Members ────────────────────────────────────────────────────────────────
@@ -56,24 +85,30 @@ export interface MembersResult {
 }
 
 export async function listDomainMembers(domainID: string, token: string): Promise<MembersResult> {
-  const page: MemberRolesPage = await sdk.Domains.ListDomainMembers(
-    domainID,
-    { limit: 100, offset: 0 } as BasicPageMeta,
-    token,
-  )
-  return { members: page.members ?? [], total: page.total ?? 0 }
+  try {
+    const page: MemberRolesPage = await sdk.Domains.ListDomainMembers(
+      domainID,
+      { limit: 100, offset: 0 } as BasicPageMeta,
+      token,
+    )
+    return { members: page.members ?? [], total: page.total ?? 0 }
+  } catch (e) { throw sdkError(e) }
 }
 
 // ── Users ──────────────────────────────────────────────────────────────────
 
 export async function listUsers(token: string): Promise<User[]> {
-  const page: UsersPage = await sdk.Users.Users({ limit: 100, offset: 0 } as PageMetadata, token)
-  return page.users ?? []
+  try {
+    const page: UsersPage = await sdk.Users.Users({ limit: 100, offset: 0 } as PageMetadata, token)
+    return page.users ?? []
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function searchUsers(query: string, token: string): Promise<User[]> {
-  const page: UsersPage = await sdk.Users.SearchUsers({ limit: 20, offset: 0, name: query } as PageMetadata, token)
-  return page.users ?? []
+  try {
+    const page: UsersPage = await sdk.Users.SearchUsers({ limit: 20, offset: 0, name: query } as PageMetadata, token)
+    return page.users ?? []
+  } catch (e) { throw sdkError(e) }
 }
 
 // ── Roles ──────────────────────────────────────────────────────────────────
@@ -100,36 +135,48 @@ export interface InvitationsResult {
 }
 
 export async function listDomainInvitations(domainID: string, token: string): Promise<InvitationsResult> {
-  const page: InvitationsPage = await sdk.Domains.ListDomainInvitations(
-    { limit: 100, offset: 0 } as InvitationPageMeta,
-    domainID,
-    token,
-  )
-  return { invitations: page.invitations ?? [], total: page.total ?? 0 }
+  try {
+    const page: InvitationsPage = await sdk.Domains.ListDomainInvitations(
+      { limit: 100, offset: 0 } as InvitationPageMeta,
+      domainID,
+      token,
+    )
+    return { invitations: page.invitations ?? [], total: page.total ?? 0 }
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function listUserInvitations(token: string): Promise<InvitationsResult> {
-  const page: InvitationsPage = await sdk.Domains.ListUserInvitations(
-    { limit: 100, offset: 0 } as PageMetadata,
-    token,
-  )
-  return { invitations: page.invitations ?? [], total: page.total ?? 0 }
+  try {
+    const page: InvitationsPage = await sdk.Domains.ListUserInvitations(
+      { limit: 100, offset: 0 } as PageMetadata,
+      token,
+    )
+    return { invitations: page.invitations ?? [], total: page.total ?? 0 }
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function sendInvitation(userID: string, domainID: string, roleID: string, token: string): Promise<void> {
-  await sdk.Domains.SendInvitation(userID, domainID, roleID, token)
+  try {
+    await sdk.Domains.SendInvitation(userID, domainID, roleID, token)
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function acceptInvitation(domainID: string, token: string): Promise<void> {
-  await sdk.Domains.AcceptInvitation(domainID, token)
+  try {
+    await sdk.Domains.AcceptInvitation(domainID, token)
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function rejectInvitation(domainID: string, token: string): Promise<void> {
-  await sdk.Domains.RejectInvitation(domainID, token)
+  try {
+    await sdk.Domains.RejectInvitation(domainID, token)
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function deleteInvitation(userID: string, domainID: string, token: string): Promise<void> {
-  await sdk.Domains.DeleteInvitation(userID, domainID, token)
+  try {
+    await sdk.Domains.DeleteInvitation(userID, domainID, token)
+  } catch (e) { throw sdkError(e) }
 }
 
 // ── Journal / Audit Logs ───────────────────────────────────────────────────
@@ -142,9 +189,11 @@ export interface JournalsResult {
 export const JOURNAL_PAGE_SIZE = 10
 
 export async function listUserJournals(userID: string, token: string, page = 0): Promise<JournalsResult> {
-  const meta: JournalsPageMetadata = { limit: JOURNAL_PAGE_SIZE, offset: page * JOURNAL_PAGE_SIZE }
-  const res: JournalsPage = await sdk.Journal.UserJournals(userID, meta, token)
-  return { journals: res.journals ?? [], total: (res as any).total ?? 0 }
+  try {
+    const meta: JournalsPageMetadata = { limit: JOURNAL_PAGE_SIZE, offset: page * JOURNAL_PAGE_SIZE }
+    const res: JournalsPage = await sdk.Journal.UserJournals(userID, meta, token)
+    return { journals: res.journals ?? [], total: (res as any).total ?? 0 }
+  } catch (e) { throw sdkError(e) }
 }
 
 export async function listEntityJournals(
@@ -154,7 +203,9 @@ export async function listEntityJournals(
   token: string,
   page = 0,
 ): Promise<JournalsResult> {
-  const meta: JournalsPageMetadata = { limit: JOURNAL_PAGE_SIZE, offset: page * JOURNAL_PAGE_SIZE }
-  const res: JournalsPage = await sdk.Journal.EntityJournals(entityType, entityId, domainId, meta, token)
-  return { journals: res.journals ?? [], total: (res as any).total ?? 0 }
+  try {
+    const meta: JournalsPageMetadata = { limit: JOURNAL_PAGE_SIZE, offset: page * JOURNAL_PAGE_SIZE }
+    const res: JournalsPage = await sdk.Journal.EntityJournals(entityType, entityId, domainId, meta, token)
+    return { journals: res.journals ?? [], total: (res as any).total ?? 0 }
+  } catch (e) { throw sdkError(e) }
 }

--- a/ui/src/pages/ChatPage.tsx
+++ b/ui/src/pages/ChatPage.tsx
@@ -300,10 +300,11 @@ function SourcesPanel({
 }
 
 export default function ChatPage() {
-  const { records, chatMessages, setChatMessages, clearChatMessages, conversationId, setConversationId, conversations, setConversations } = useOutletContext<AppContext>()
+  const { records, chatMessages, setChatMessages, clearChatMessages, conversationId, setConversationId, conversations, setConversations, activeDomain } = useOutletContext<AppContext>()
   const { tokens } = useAuth()
   const location = useLocation()
   const accessToken = tokens?.accessToken
+  const domainID = activeDomain?.id ?? ''
   const routeState = (location.state ?? null) as ChatRouteState | null
   const selectedRecord = routeState?.source
   const selectedSourceID = routeState?.sourceID
@@ -341,7 +342,7 @@ export default function ChatPage() {
     if (!accessToken || loadingConv) return
     setLoadingConv(true)
     try {
-      const { messages } = await getConversation(accessToken, id)
+      const { messages } = await getConversation(accessToken, domainID, id)
       setChatMessages(messages)
       setConversationId(id)
     } catch (err) {
@@ -354,7 +355,7 @@ export default function ChatPage() {
   const handleDeleteConversation = useCallback(async (id: string) => {
     if (!accessToken) return
     try {
-      await deleteConversation(accessToken, id)
+      await deleteConversation(accessToken, domainID, id)
       setConversations(prev => prev.filter(c => c.id !== id))
       if (conversationId === id) {
         clearChatMessages()
@@ -399,7 +400,7 @@ export default function ChatPage() {
     if (!selectedSourceID || !accessToken) return
     let cancelled = false
 
-    listRecordsBySource(accessToken, selectedSourceID)
+    listRecordsBySource(accessToken, domainID, selectedSourceID)
       .then(nextRecords => {
         if (cancelled) return
         const indexedRecordIDs = nextRecords
@@ -428,8 +429,8 @@ export default function ChatPage() {
     setSourceSyncNotice({ sourceID: selectedSourceID, kind: 'info', text: 'Sync in progress...' })
 
     try {
-      const res = await syncSource(accessToken, selectedSourceID)
-      const nextRecords = await listRecordsBySource(accessToken, selectedSourceID)
+      const res = await syncSource(accessToken, domainID, selectedSourceID)
+      const nextRecords = await listRecordsBySource(accessToken, domainID, selectedSourceID)
       const indexedRecordIDs = nextRecords
         .filter(r => r.status === 'indexed' && (r.chunks ?? 0) > 0)
         .map(r => r.id)
@@ -501,6 +502,7 @@ export default function ChatPage() {
 
     streamChat(
       accessToken,
+      domainID,
       apiMessages,
       targetRecordIDs,
       (event) => {

--- a/ui/src/pages/DomainsPage.tsx
+++ b/ui/src/pages/DomainsPage.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useOutletContext } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
-import { listDomains, createDomain } from '@/lib/platform/service'
+import { listDomains, createDomain, deleteDomain, toRoute } from '@/lib/platform/service'
 import type { Domain } from '@/lib/platform/service'
 import type { AppContext } from '@/types'
 import UserMenu from '@/components/UserMenu'
@@ -38,16 +38,28 @@ function DomainIcon({ name }: { name: string }) {
 function CreateDomainModal({ onClose, onCreated }: { onClose: () => void; onCreated: (d: Domain) => void }) {
   const { tokens } = useAuth()
   const [name, setName] = useState('')
+  const [route, setRoute] = useState('')
+  const [routeEdited, setRouteEdited] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  function handleNameChange(value: string) {
+    setName(value)
+    if (!routeEdited) setRoute(toRoute(value))
+  }
+
+  function handleRouteChange(value: string) {
+    setRouteEdited(true)
+    setRoute(value.toLowerCase().replace(/[^a-z0-9-]/g, ''))
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!tokens?.accessToken || !name.trim()) return
+    if (!tokens?.accessToken || !name.trim() || !route.trim()) return
     setLoading(true)
     setError(null)
     try {
-      const domain = await createDomain(name.trim(), tokens.accessToken)
+      const domain = await createDomain(name.trim(), route.trim(), tokens.accessToken)
       onCreated(domain)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create domain')
@@ -56,9 +68,11 @@ function CreateDomainModal({ onClose, onCreated }: { onClose: () => void; onCrea
     }
   }
 
+  const canSubmit = !loading && !!name.trim() && !!route.trim()
+
   return (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100 }} onClick={onClose}>
-      <div style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', borderRadius: '14px', padding: '28px', width: '360px', boxShadow: '0 24px 80px rgba(0,0,0,0.5)' }} onClick={e => e.stopPropagation()}>
+      <div style={{ background: 'var(--card-bg)', border: '1px solid var(--border)', borderRadius: '14px', padding: '28px', width: '380px', boxShadow: '0 24px 80px rgba(0,0,0,0.5)' }} onClick={e => e.stopPropagation()}>
         <h2 style={{ fontFamily: 'Space Grotesk, sans-serif', fontWeight: '700', fontSize: '18px', color: 'var(--text)', margin: '0 0 4px', letterSpacing: '-0.02em' }}>
           Create domain
         </h2>
@@ -73,11 +87,24 @@ function CreateDomainModal({ onClose, onCreated }: { onClose: () => void; onCrea
             </label>
             <input
               type="text"
-              placeholder="e.g. my-workspace"
+              placeholder="e.g. My Workspace"
               value={name}
-              onChange={e => setName(e.target.value)}
+              onChange={e => handleNameChange(e.target.value)}
               autoFocus
               style={{ width: '100%', background: 'rgba(255,255,255,0.04)', border: '1px solid var(--border)', borderRadius: '8px', padding: '9px 12px', color: 'var(--text)', fontFamily: 'Space Grotesk, sans-serif', fontSize: '14px', outline: 'none', boxSizing: 'border-box' }}
+            />
+          </div>
+
+          <div>
+            <label style={{ display: 'block', fontFamily: 'Space Grotesk, sans-serif', fontWeight: '600', fontSize: '12px', color: 'var(--text)', marginBottom: '5px' }}>
+              Route <span style={{ fontWeight: '400', color: 'var(--text-muted)' }}>(must be unique)</span>
+            </label>
+            <input
+              type="text"
+              placeholder="e.g. my-workspace"
+              value={route}
+              onChange={e => handleRouteChange(e.target.value)}
+              style={{ width: '100%', background: 'rgba(255,255,255,0.04)', border: '1px solid var(--border)', borderRadius: '8px', padding: '9px 12px', color: 'var(--text)', fontFamily: 'JetBrains Mono, monospace', fontSize: '13px', outline: 'none', boxSizing: 'border-box' }}
             />
           </div>
 
@@ -97,8 +124,8 @@ function CreateDomainModal({ onClose, onCreated }: { onClose: () => void; onCrea
             </button>
             <button
               type="submit"
-              disabled={loading || !name.trim()}
-              style={{ padding: '8px 18px', borderRadius: '8px', border: 'none', background: loading || !name.trim() ? 'rgba(0,212,180,0.4)' : 'var(--accent)', color: '#070c16', fontFamily: 'Space Grotesk, sans-serif', fontSize: '13px', fontWeight: '700', cursor: loading || !name.trim() ? 'not-allowed' : 'pointer' }}
+              disabled={!canSubmit}
+              style={{ padding: '8px 18px', borderRadius: '8px', border: 'none', background: !canSubmit ? 'rgba(0,212,180,0.4)' : 'var(--accent)', color: '#070c16', fontFamily: 'Space Grotesk, sans-serif', fontSize: '13px', fontWeight: '700', cursor: !canSubmit ? 'not-allowed' : 'pointer' }}
             >
               {loading ? 'Creating…' : 'Create'}
             </button>
@@ -115,18 +142,19 @@ export default function DomainsPage() {
 
   const [domains, setDomains] = useState<Domain[]>([])
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
   const [showCreate, setShowCreate] = useState(false)
 
   const load = useCallback(async () => {
     if (!tokens?.accessToken) return
     setLoading(true)
-    setError(null)
+    setLoadError(null)
     try {
       const list = await listDomains(tokens.accessToken)
       setDomains(list)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load domains')
+      setLoadError(err instanceof Error ? err.message : 'Failed to load domains')
     } finally {
       setLoading(false)
     }
@@ -135,12 +163,27 @@ export default function DomainsPage() {
   useEffect(() => { void load() }, [load])
 
   function handleSelect(domain: Domain) {
+    const id = domain.id ?? ''
+    if (!id) return
     setActiveDomain({
-      id: domain.id ?? '',
+      id,
       name: domain.name ?? '',
       route: domain.route,
       status: domain.status as string | undefined,
     })
+  }
+
+  async function handleDelete(domain: Domain) {
+    if (!tokens?.accessToken) return
+    if (!window.confirm(`Delete domain "${domain.name}"? This cannot be undone.`)) return
+    setActionError(null)
+    try {
+      await deleteDomain(domain.id ?? '', tokens.accessToken)
+      setDomains(prev => prev.filter(d => d.id !== domain.id))
+      if (activeDomain?.id === domain.id) setActiveDomain(null)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to delete domain')
+    }
   }
 
   function handleCreated(domain: Domain) {
@@ -183,13 +226,19 @@ export default function DomainsPage() {
           </div>
         )}
 
-        {!loading && error && (
+        {!loading && loadError && (
           <div style={{ padding: '14px 16px', background: 'rgba(255,107,107,0.08)', border: '1px solid rgba(255,107,107,0.2)', borderRadius: '10px', fontFamily: 'Space Grotesk, sans-serif', fontSize: '13px', color: '#ff6b6b' }}>
-            {error}
+            {loadError}
           </div>
         )}
 
-        {!loading && !error && domains.length === 0 && (
+        {actionError && (
+          <div style={{ padding: '14px 16px', marginBottom: '16px', background: 'rgba(255,107,107,0.08)', border: '1px solid rgba(255,107,107,0.2)', borderRadius: '10px', fontFamily: 'Space Grotesk, sans-serif', fontSize: '13px', color: '#ff6b6b' }}>
+            {actionError}
+          </div>
+        )}
+
+        {!loading && !loadError && domains.length === 0 && (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '300px', gap: '12px' }}>
             <div style={{ width: '48px', height: '48px', borderRadius: '12px', background: 'rgba(255,255,255,0.04)', border: '1px solid var(--border)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
               <svg width="22" height="22" viewBox="0 0 20 20" fill="none">
@@ -208,7 +257,7 @@ export default function DomainsPage() {
           </div>
         )}
 
-        {!loading && !error && domains.length > 0 && (
+        {!loading && !loadError && domains.length > 0 && (
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '12px' }}>
             {domains.map(domain => {
               const isActive = activeDomain?.id === domain.id
@@ -253,12 +302,20 @@ export default function DomainsPage() {
 
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                     <StatusBadge status={domain.status as string | undefined} />
-                    <button
-                      onClick={e => { e.stopPropagation(); handleSelect(domain) }}
-                      style={{ padding: '4px 10px', border: `1px solid ${isActive ? 'rgba(0,212,180,0.4)' : 'var(--border)'}`, borderRadius: '6px', background: isActive ? 'rgba(0,212,180,0.1)' : 'transparent', color: isActive ? 'var(--accent)' : 'var(--text-muted)', fontFamily: 'Space Grotesk, sans-serif', fontSize: '11px', fontWeight: '600', cursor: 'pointer' }}
-                    >
-                      {isActive ? 'Active' : 'Select'}
-                    </button>
+                    <div style={{ display: 'flex', gap: '6px' }}>
+                      <button
+                        onClick={e => { e.stopPropagation(); handleSelect(domain) }}
+                        style={{ padding: '4px 10px', border: `1px solid ${isActive ? 'rgba(0,212,180,0.4)' : 'var(--border)'}`, borderRadius: '6px', background: isActive ? 'rgba(0,212,180,0.1)' : 'transparent', color: isActive ? 'var(--accent)' : 'var(--text-muted)', fontFamily: 'Space Grotesk, sans-serif', fontSize: '11px', fontWeight: '600', cursor: 'pointer' }}
+                      >
+                        {isActive ? 'Active' : 'Select'}
+                      </button>
+                      <button
+                        onClick={e => { e.stopPropagation(); void handleDelete(domain) }}
+                        style={{ padding: '4px 10px', border: '1px solid rgba(255,80,80,0.3)', borderRadius: '6px', background: 'transparent', color: '#ff5050', fontFamily: 'Space Grotesk, sans-serif', fontSize: '11px', fontWeight: '600', cursor: 'pointer' }}
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </div>
                 </div>
               )

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -195,7 +195,7 @@ function DetailPanel({ record, onClose, onStartChat }: { record: AppRecord; onCl
 export default function HomePage() {
   const navigate = useNavigate()
   const { tokens } = useAuth()
-  const { records, setRecords, driveSources, setDriveSources } = useOutletContext<AppContext>()
+  const { records, setRecords, driveSources, setDriveSources, activeDomain } = useOutletContext<AppContext>()
   const [selected, setSelected] = useState<AppRecord | null>(null)
   const [showAddRecord, setShowAddRecord] = useState(false)
   const [showAddSource, setShowAddSource] = useState(false)
@@ -208,6 +208,7 @@ export default function HomePage() {
   const [editingSource, setEditingSource] = useState<DriveSource | null>(null)
 
   const accessToken = tokens?.accessToken ?? ''
+  const domainID = activeDomain?.id ?? ''
   const cachedGoogleSource = driveSources.find(source => source.sourceType === 'google_drive' && !!source.accessToken)
 
   const refreshData = useCallback(async () => {
@@ -220,8 +221,8 @@ export default function HomePage() {
     setIsLoading(true)
     try {
       const [nextSources, nextRecords] = await Promise.all([
-        listSources(accessToken),
-        listRecords(accessToken),
+        listSources(accessToken, domainID),
+        listRecords(accessToken, domainID),
       ])
       setDriveSources(nextSources)
       setRecords(nextRecords)
@@ -232,7 +233,7 @@ export default function HomePage() {
     } finally {
       setIsLoading(false)
     }
-  }, [accessToken, setDriveSources, setRecords])
+  }, [accessToken, domainID, setDriveSources, setRecords])
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -256,9 +257,9 @@ export default function HomePage() {
       throw new Error('Authentication token is missing')
     }
 
-    const created = await createSource(accessToken, source)
+    const created = await createSource(accessToken, domainID, source)
     try {
-      await syncSource(accessToken, created.id)
+      await syncSource(accessToken, domainID, created.id)
     } catch (err) {
       console.error('source sync failed', err)
       setLoadError(
@@ -276,14 +277,14 @@ export default function HomePage() {
       throw new Error('Authentication token is missing')
     }
 
-    await uploadRecordFile(accessToken, file)
+    await uploadRecordFile(accessToken, domainID, file)
     await refreshData()
   }
 
   async function handleDeleteRecord(e: React.MouseEvent, id: string) {
     e.stopPropagation()
     if (!accessToken) return
-    await deleteRecord(accessToken, id)
+    await deleteRecord(accessToken, domainID, id)
     if (selected?.id === id) setSelected(null)
     await refreshData()
   }
@@ -291,7 +292,7 @@ export default function HomePage() {
   async function handleRetryRecordIngest(record: AppRecord) {
     if (!accessToken) return
     try {
-      await retryRecordIngest(accessToken, record.id)
+      await retryRecordIngest(accessToken, domainID, record.id)
       setLoadError('')
       await refreshData()
     } catch (err) {
@@ -307,7 +308,7 @@ export default function HomePage() {
       [sourceID]: { kind: 'info', text: 'Sync in progress...' },
     }))
     try {
-      const res = await syncSource(accessToken, sourceID)
+      const res = await syncSource(accessToken, domainID, sourceID)
       setLoadError('')
       setSourceSyncNotice(prev => ({
         ...prev,
@@ -332,7 +333,7 @@ export default function HomePage() {
     if (!accessToken) return
     if (!window.confirm('Delete this source?')) return
     try {
-      await deleteSource(accessToken, sourceID)
+      await deleteSource(accessToken, domainID, sourceID)
       setLoadError('')
       await refreshData()
     } catch (err) {
@@ -343,7 +344,7 @@ export default function HomePage() {
   async function handleSaveSourceSelection(source: DriveSource, selectedFileIDs: string[]) {
     if (!accessToken) return
     try {
-      await updateGoogleSourceSelection(accessToken, source.id, selectedFileIDs, source.selectedFolderIDs ?? [])
+      await updateGoogleSourceSelection(accessToken, domainID, source.id, selectedFileIDs, source.selectedFolderIDs ?? [])
       await handleRetrySourceSync(source.id)
       setLoadError('')
       await refreshData()

--- a/ui/src/pages/RecordsPage.tsx
+++ b/ui/src/pages/RecordsPage.tsx
@@ -203,7 +203,7 @@ function DetailPanel({ record, onClose, onStartChat, onRetry }: { record: AppRec
 export default function RecordsPage() {
   const navigate = useNavigate()
   const { tokens } = useAuth()
-  const { records, setRecords } = useOutletContext<AppContext>()
+  const { records, setRecords, activeDomain } = useOutletContext<AppContext>()
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const selected = records.find(r => r.id === selectedId) ?? null
   const [showAddRecord, setShowAddRecord] = useState(false)
@@ -213,17 +213,18 @@ export default function RecordsPage() {
   const [refreshTick, setRefreshTick] = useState(0)
 
   const accessToken = tokens?.accessToken ?? ''
+  const domainID = activeDomain?.id ?? ''
 
   const refreshRecords = useCallback(() => { setRefreshTick(t => t + 1) }, [])
 
   useEffect(() => {
     if (!accessToken) return
     let active = true
-    listRecords(accessToken)
+    listRecords(accessToken, domainID)
       .then(data => { if (active) { setRecords(data); setError(''); setHasLoaded(true) } })
       .catch(err => { if (active) { setError(err instanceof Error ? err.message : 'Failed to load records'); setHasLoaded(true) } })
     return () => { active = false }
-  }, [accessToken, setRecords, refreshTick])
+  }, [accessToken, domainID, setRecords, refreshTick])
 
   const filtered = records.filter(r =>
     r.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -232,14 +233,14 @@ export default function RecordsPage() {
 
   async function handleUploadRecord(file: File) {
     if (!accessToken) throw new Error('Authentication token is missing')
-    await uploadRecordFile(accessToken, file)
+    await uploadRecordFile(accessToken, domainID, file)
     refreshRecords()
   }
 
   async function handleRetryRecord(id: string) {
     if (!accessToken) return
     try {
-      await retryRecordIngest(accessToken, id)
+      await retryRecordIngest(accessToken, domainID, id)
       refreshRecords()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to retry ingest')
@@ -250,7 +251,7 @@ export default function RecordsPage() {
     e.stopPropagation()
     if (!accessToken) return
     try {
-      await deleteRecord(accessToken, id)
+      await deleteRecord(accessToken, domainID, id)
       if (selectedId === id) setSelectedId(null)
       refreshRecords()
     } catch (err) {

--- a/ui/src/pages/SourcesPage.tsx
+++ b/ui/src/pages/SourcesPage.tsx
@@ -148,7 +148,7 @@ function SourceRow(
 export default function SourcesPage() {
   const navigate = useNavigate()
   const { tokens } = useAuth()
-  const { driveSources, setDriveSources } = useOutletContext<AppContext>()
+  const { driveSources, setDriveSources, activeDomain } = useOutletContext<AppContext>()
   const [showAddSource, setShowAddSource] = useState(false)
   const [editingSource, setEditingSource] = useState<DriveSource | null>(null)
   const [hasLoaded, setHasLoaded] = useState(false)
@@ -156,6 +156,7 @@ export default function SourcesPage() {
   const [syncing, setSyncing] = useState<Record<string, boolean>>({})
 
   const accessToken = tokens?.accessToken ?? ''
+  const domainID = activeDomain?.id ?? ''
 
   const [refreshTick, setRefreshTick] = useState(0)
   const refreshSources = useCallback(() => { setRefreshTick(t => t + 1) }, [])
@@ -164,18 +165,18 @@ export default function SourcesPage() {
   useEffect(() => {
     if (!accessToken) return
     let active = true
-    listSources(accessToken)
+    listSources(accessToken, domainID)
       .then(data => { if (active) { setDriveSources(data); setError(''); setHasLoaded(true) } })
       .catch(err => { if (active) { setError(err instanceof Error ? err.message : 'Failed to load sources'); setHasLoaded(true) } })
     return () => { active = false }
-  }, [accessToken, setDriveSources, refreshTick])
+  }, [accessToken, domainID, setDriveSources, refreshTick])
 
   async function handleAddSource(source: DriveSourceDraft) {
     if (!accessToken) throw new Error('Authentication token is missing')
-    const created = await createSource(accessToken, source)
+    const created = await createSource(accessToken, domainID, source)
     refreshSources()
     setSyncing(prev => ({ ...prev, [created.id]: true }))
-    void syncSource(accessToken, created.id)
+    void syncSource(accessToken, domainID, created.id)
       .then(() => {
         refreshSources()
       })
@@ -191,7 +192,7 @@ export default function SourcesPage() {
     if (!accessToken || syncing[id]) return
     setSyncing(prev => ({ ...prev, [id]: true }))
     try {
-      await syncSource(accessToken, id)
+      await syncSource(accessToken, domainID, id)
       refreshSources()
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Sync failed')
@@ -204,7 +205,7 @@ export default function SourcesPage() {
     if (!accessToken) return
     if (!window.confirm('Delete this source?')) return
     try {
-      await deleteSource(accessToken, id)
+      await deleteSource(accessToken, domainID, id)
       refreshSources()
       setError('')
     } catch (err) {
@@ -215,7 +216,7 @@ export default function SourcesPage() {
   async function handleSaveSourceSelection(source: DriveSource, selectedFileIDs: string[]) {
     if (!accessToken) return
     try {
-      await updateGoogleSourceSelection(accessToken, source.id, selectedFileIDs, source.selectedFolderIDs ?? [])
+      await updateGoogleSourceSelection(accessToken, domainID, source.id, selectedFileIDs, source.selectedFolderIDs ?? [])
       await handleSync(source.id)
       refreshSources()
       setError('')


### PR DESCRIPTION
<!--
Copyright (c) Ultraviolet
SPDX-License-Identifier: Apache-2.0
-->

<!--

Pull request title should be `UV-XXX - description` or `COCOS-XXX - description` or `NOISSUE - description` where XXX is the ID of the issue that this PR relate to. Please review the [CONTRIBUTING.md](https://github.com/ultravioletrs/.github/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please avoid force-pushing additional commits for a timely review/response if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits.
- Update any related documentation.
-->

# What type of PR is this?

This is a feature because it adds domain isolation to the embedder service and UI, scoping all records, sources, chunks, and conversations to a specific domain (workspace).

## What does this do?

Adds full domain isolation across the embedder stack so that records, sources, vector chunks, and conversations are scoped per domain (workspace). Key changes:

- **Auth middleware**: reads `X-Domain-ID` request header and stores it in context
- **All transport handlers**: extract `domainID` from context and pass it through the service layer
- **All service implementations**: accept and forward `domainID` to repository calls
- **PostgreSQL repositories**: all queries filter by `domain_id`; `scanRecord` and `scanSource` now scan the `domain_id` column (fixes indexing failure caused by empty domain_id in queued record lookups)
- **DB migration** (`005_domain_isolation.sql`): adds `domain_id TEXT NOT NULL DEFAULT ''` + indexes to sources, records, chunks, and conversations tables
- **Ingest worker**: passes `rec.DomainID` to `StoreChunks` so chunks are stored under the correct domain
- **UI**: all API calls send the active domain ID as `X-Domain-ID`; domain switch clears and reloads all domain-scoped data
- **Chat service**: improved RAG prompt to allow complete, thorough answers using both retrieved excerpts and general knowledge
- **Dockerfile**: fixed invalid `COPY .. .` → `COPY . .`

## Which issue(s) does this PR fix/relate to?

<!--
- Related Issue #
- Resolves #
-->

## Have you included tests for your changes?

No. The domain isolation logic is straightforward pass-through of a string identifier; integration tests against a real PostgreSQL instance with the migration applied would be needed to cover this properly.

## Did you document any new/modified features?

No. The `X-Domain-ID` header is the only new API contract and is documented implicitly by the middleware code.

### Notes

The `embedder` compiled binary has been removed from git tracking and added to `.gitignore`. It was previously committed by mistake.