### PR TITLE
Add attestation proxy routing and no-policy response handling

### DIFF
--- a/proxy/postgres/repo.go
+++ b/proxy/postgres/repo.go
@@ -5,7 +5,9 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 
 	"github.com/absmach/supermq/pkg/postgres"
 	"github.com/ultravioletrs/cube/proxy"
@@ -30,6 +32,9 @@ func (r *repository) GetAttestationPolicy(ctx context.Context) ([]byte, error) {
 
 	row := r.db.QueryRowxContext(ctx, q)
 	if err := row.Scan(&policy); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/proxy/postgres/repo.go
+++ b/proxy/postgres/repo.go
@@ -35,6 +35,7 @@ func (r *repository) GetAttestationPolicy(ctx context.Context) ([]byte, error) {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
+
 		return nil, err
 	}
 

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -18,12 +18,3 @@ VITE_OAUTH_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 # Set to "true" to show the Attestation page and nav item.
 # When false (default), all attestation UI is hidden.
 VITE_ENABLE_ATTESTATION=false
-
-# Base URL of the Cube Proxy service.
-# In production, leave empty — nginx routes /{domainID}/... to the proxy at the same origin.
-# In local dev, point to the proxy directly: http://localhost:9090
-VITE_CUBE_PROXY_URL=
-
-# Dev-server proxy target for Cube Proxy (used by vite.config.ts only, not inlined into the bundle).
-# Set this when VITE_CUBE_PROXY_URL is empty but you still want dev proxying via Vite.
-CUBE_PROXY_TARGET=

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -13,3 +13,17 @@ VITE_MAGISTRALA_USERS_URL=http://localhost:9002
 # Create at: console.cloud.google.com → APIs & Services → Credentials → OAuth 2.0 Client ID
 # Type: Web application. Add http://localhost:5173 as an Authorized JavaScript origin.
 VITE_OAUTH_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+
+# Attestation feature flag.
+# Set to "true" to show the Attestation page and nav item.
+# When false (default), all attestation UI is hidden.
+VITE_ENABLE_ATTESTATION=false
+
+# Base URL of the Cube Proxy service.
+# In production, leave empty — nginx routes /{domainID}/... to the proxy at the same origin.
+# In local dev, point to the proxy directly: http://localhost:9090
+VITE_CUBE_PROXY_URL=
+
+# Dev-server proxy target for Cube Proxy (used by vite.config.ts only, not inlined into the bundle).
+# Set this when VITE_CUBE_PROXY_URL is empty but you still want dev proxying via Vite.
+CUBE_PROXY_TARGET=

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,7 +14,9 @@ import MembersPage from '@/pages/MembersPage'
 import InvitationsPage from '@/pages/InvitationsPage'
 import AuditLogsPage from '@/pages/AuditLogsPage'
 import OAuthGoogleCallbackPage from '@/pages/OAuthGoogleCallbackPage'
+import AttestationPage from '@/pages/AttestationPage'
 import { useAuth } from '@/hooks/useAuth'
+import { ATTESTATION_ENABLED } from '@/lib/features'
 
 function LandingPage() {
   const { isAuthenticated } = useAuth()
@@ -90,6 +92,9 @@ export default function App() {
         <Route path="/members" element={<MembersPage />} />
         <Route path="/invitations" element={<InvitationsPage />} />
         <Route path="/audit-logs" element={<AuditLogsPage />} />
+        {ATTESTATION_ENABLED && (
+          <Route path="/attestation" element={<AttestationPage />} />
+        )}
       </Route>
     </Routes>
   )

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
+import { ATTESTATION_ENABLED } from '@/lib/features'
 import type { ActiveDomain } from '@/types'
 
 const CubeAILogo = () => (
@@ -127,6 +128,17 @@ const platformItems: NavItem[] = [
       </svg>
     ),
   },
+  ...(ATTESTATION_ENABLED ? [{
+    id: 'attestation',
+    label: 'Attestation',
+    path: '/attestation',
+    icon: (
+      <svg width="16" height="16" viewBox="0 0 20 20" fill="none">
+        <path d="M10 2L3 5v5c0 4.418 3.134 8.547 7 9.5C13.866 18.547 17 14.418 17 10V5l-7-3z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+        <path d="M7 10l2 2 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    ),
+  }] : []),
 ]
 
 const bottomItems: NavItem[] = [

--- a/ui/src/lib/attestation.ts
+++ b/ui/src/lib/attestation.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Ultraviolet
+// SPDX-License-Identifier: Apache-2.0
+
+import { CUBE_PROXY_URL } from './features'
+
+function proxyURL(path: string): string {
+  return `${CUBE_PROXY_URL}${path}`
+}
+
+// AttestationPolicy is the raw JSON stored as JSONB on the proxy.
+// The schema is intentionally open — it is defined by the attestation provider.
+export type AttestationPolicy = Record<string, unknown>
+
+// getAttestationPolicy fetches the latest attestation policy for a domain.
+// Endpoint: GET /{domainID}/attestation/policy
+export async function getAttestationPolicy(
+  token: string,
+  domainID: string,
+): Promise<AttestationPolicy | null> {
+  const res = await fetch(proxyURL(`/${domainID}/attestation/policy`), {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`getAttestationPolicy: ${res.status} ${res.statusText}`)
+  const body = await res.text()
+  if (!body.trim()) return null
+  return JSON.parse(body) as AttestationPolicy
+}
+
+// updateAttestationPolicy stores a new attestation policy.
+// Endpoint: POST /attestation/policy
+export async function updateAttestationPolicy(
+  token: string,
+  policy: AttestationPolicy,
+): Promise<void> {
+  const res = await fetch(proxyURL('/attestation/policy'), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(policy),
+  })
+  if (!res.ok) throw new Error(`updateAttestationPolicy: ${res.status} ${res.statusText}`)
+}

--- a/ui/src/lib/attestation.ts
+++ b/ui/src/lib/attestation.ts
@@ -1,23 +1,18 @@
 // Copyright (c) Ultraviolet
 // SPDX-License-Identifier: Apache-2.0
 
-import { CUBE_PROXY_URL } from './features'
-
-function proxyURL(path: string): string {
-  return `${CUBE_PROXY_URL}${path}`
-}
-
 // AttestationPolicy is the raw JSON stored as JSONB on the proxy.
 // The schema is intentionally open — it is defined by the attestation provider.
 export type AttestationPolicy = Record<string, unknown>
 
 // getAttestationPolicy fetches the latest attestation policy for a domain.
-// Endpoint: GET /{domainID}/attestation/policy
+// Traefik routes /proxy/* → cube-proxy (strips the /proxy prefix).
+// Endpoint: GET /proxy/{domainID}/attestation/policy
 export async function getAttestationPolicy(
   token: string,
   domainID: string,
 ): Promise<AttestationPolicy | null> {
-  const res = await fetch(proxyURL(`/${domainID}/attestation/policy`), {
+  const res = await fetch(`/proxy/${domainID}/attestation/policy`, {
     headers: { Authorization: `Bearer ${token}` },
   })
   if (res.status === 404) return null
@@ -28,12 +23,12 @@ export async function getAttestationPolicy(
 }
 
 // updateAttestationPolicy stores a new attestation policy.
-// Endpoint: POST /attestation/policy
+// Endpoint: POST /proxy/attestation/policy
 export async function updateAttestationPolicy(
   token: string,
   policy: AttestationPolicy,
 ): Promise<void> {
-  const res = await fetch(proxyURL('/attestation/policy'), {
+  const res = await fetch('/proxy/attestation/policy', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,

--- a/ui/src/lib/features.ts
+++ b/ui/src/lib/features.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Ultraviolet
+// SPDX-License-Identifier: Apache-2.0
+
+// Feature flags — set via VITE_* environment variables at build time.
+// All values default to disabled/empty so a vanilla deployment is unaffected.
+
+export const ATTESTATION_ENABLED = import.meta.env.VITE_ENABLE_ATTESTATION === 'true'
+
+// Base URL of the Cube Proxy service (e.g. http://localhost:9090).
+// Leave empty in production when nginx routes /{domainID}/... to the proxy.
+export const CUBE_PROXY_URL: string = import.meta.env.VITE_CUBE_PROXY_URL ?? ''

--- a/ui/src/lib/features.ts
+++ b/ui/src/lib/features.ts
@@ -5,7 +5,3 @@
 // All values default to disabled/empty so a vanilla deployment is unaffected.
 
 export const ATTESTATION_ENABLED = import.meta.env.VITE_ENABLE_ATTESTATION === 'true'
-
-// Base URL of the Cube Proxy service (e.g. http://localhost:9090).
-// Leave empty in production when nginx routes /{domainID}/... to the proxy.
-export const CUBE_PROXY_URL: string = import.meta.env.VITE_CUBE_PROXY_URL ?? ''

--- a/ui/src/pages/AttestationPage.tsx
+++ b/ui/src/pages/AttestationPage.tsx
@@ -1,0 +1,246 @@
+// Copyright (c) Ultraviolet
+// SPDX-License-Identifier: Apache-2.0
+import { useCallback, useEffect, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import { useAuth } from '@/hooks/useAuth'
+import { getAttestationPolicy, updateAttestationPolicy } from '@/lib/attestation'
+import type { AttestationPolicy } from '@/lib/attestation'
+import type { AppContext } from '@/types'
+
+function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: '5px',
+      background: ok ? 'rgba(0,212,180,0.1)' : 'rgba(255,80,80,0.1)',
+      color: ok ? '#00d4b4' : '#ff5050',
+      fontFamily: 'JetBrains Mono, monospace', fontSize: '10px',
+      padding: '3px 10px', borderRadius: '20px', fontWeight: '500',
+    }}>
+      <span style={{ width: '6px', height: '6px', borderRadius: '50%', background: 'currentColor', display: 'inline-block' }} />
+      {label}
+    </span>
+  )
+}
+
+function InfoCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{
+      background: 'rgba(0,212,180,0.04)', border: '1px solid rgba(0,212,180,0.15)',
+      borderRadius: '10px', padding: '16px 20px',
+    }}>
+      <p style={{ margin: '0 0 8px', fontFamily: 'Space Grotesk, sans-serif', fontWeight: '600', fontSize: '12px', color: '#00d4b4', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+        {title}
+      </p>
+      {children}
+    </div>
+  )
+}
+
+export default function AttestationPage() {
+  const { tokens } = useAuth()
+  const { activeDomain } = useOutletContext<AppContext>()
+
+  const [policy, setPolicy] = useState<AttestationPolicy | null>(null)
+  const [draft, setDraft] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+  const [parseError, setParseError] = useState<string | null>(null)
+
+  const domainID = activeDomain?.id ?? ''
+
+  const load = useCallback(async () => {
+    if (!tokens?.accessToken || !domainID) return
+    setLoading(true)
+    setError(null)
+    try {
+      const p = await getAttestationPolicy(tokens.accessToken, domainID)
+      setPolicy(p)
+      setDraft(p ? JSON.stringify(p, null, 2) : '')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load policy')
+    } finally {
+      setLoading(false)
+    }
+  }, [tokens?.accessToken, domainID])
+
+  useEffect(() => { void load() }, [load])
+
+  function handleDraftChange(value: string) {
+    setDraft(value)
+    setSaved(false)
+    try {
+      JSON.parse(value)
+      setParseError(null)
+    } catch {
+      setParseError('Invalid JSON')
+    }
+  }
+
+  async function handleSave() {
+    if (!tokens?.accessToken) return
+    setSaveError(null)
+    setSaving(true)
+    try {
+      const parsed = JSON.parse(draft) as AttestationPolicy
+      await updateAttestationPolicy(tokens.accessToken, parsed)
+      setPolicy(parsed)
+      setSaved(true)
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : 'Failed to save policy')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const hasChanges = draft !== (policy ? JSON.stringify(policy, null, 2) : '')
+  const canSave = !parseError && hasChanges && !saving && !!draft.trim()
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Header */}
+      <div style={{ padding: '24px 28px 0', borderBottom: '1px solid var(--border)', paddingBottom: '16px', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div>
+            <h1 style={{ margin: 0, fontFamily: 'Space Grotesk, sans-serif', fontWeight: '700', fontSize: '20px', color: 'var(--text)', letterSpacing: '-0.02em' }}>
+              Attestation
+            </h1>
+            <p style={{ margin: '4px 0 0', fontFamily: 'JetBrains Mono, monospace', fontSize: '11px', color: 'var(--text-dim)' }}>
+              Manage aTLS attestation policy for domain: {domainID || '—'}
+            </p>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {policy !== null ? (
+              <StatusBadge ok label="Policy configured" />
+            ) : (
+              !loading && <StatusBadge ok={false} label="No policy" />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div style={{ flex: 1, overflow: 'auto', padding: '24px 28px', display: 'flex', gap: '24px' }}>
+        {/* Left — editor */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '12px', minWidth: 0 }}>
+          {!domainID && (
+            <div style={{ background: 'rgba(255,180,0,0.08)', border: '1px solid rgba(255,180,0,0.2)', borderRadius: '10px', padding: '14px 18px' }}>
+              <p style={{ margin: 0, fontFamily: 'Space Grotesk, sans-serif', fontSize: '13px', color: '#ffb400' }}>
+                Select a domain to view or edit its attestation policy.
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <div style={{ background: 'rgba(255,80,80,0.08)', border: '1px solid rgba(255,80,80,0.2)', borderRadius: '10px', padding: '14px 18px' }}>
+              <p style={{ margin: 0, fontFamily: 'JetBrains Mono, monospace', fontSize: '12px', color: '#ff5050' }}>{error}</p>
+            </div>
+          )}
+
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <p style={{ margin: 0, fontFamily: 'Space Grotesk, sans-serif', fontWeight: '600', fontSize: '13px', color: 'var(--text-muted)' }}>
+              Policy (JSON)
+            </p>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              {parseError && (
+                <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: '#ff5050' }}>{parseError}</span>
+              )}
+              {saved && !hasChanges && (
+                <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: '#00d4b4' }}>Saved</span>
+              )}
+              <button
+                onClick={() => void load()}
+                disabled={loading || !domainID}
+                style={{
+                  background: 'rgba(255,255,255,0.05)', border: '1px solid var(--border)',
+                  borderRadius: '7px', color: 'var(--text-muted)', fontFamily: 'Space Grotesk, sans-serif',
+                  fontSize: '12px', padding: '5px 12px', cursor: 'pointer', opacity: loading ? 0.5 : 1,
+                }}
+              >
+                {loading ? 'Loading…' : 'Refresh'}
+              </button>
+              <button
+                onClick={() => void handleSave()}
+                disabled={!canSave}
+                style={{
+                  background: canSave ? 'var(--accent)' : 'rgba(0,212,180,0.2)',
+                  border: 'none', borderRadius: '7px',
+                  color: canSave ? '#070c16' : 'var(--text-dim)',
+                  fontFamily: 'Space Grotesk, sans-serif', fontWeight: '600',
+                  fontSize: '12px', padding: '5px 14px', cursor: canSave ? 'pointer' : 'not-allowed',
+                  transition: 'all 0.12s ease',
+                }}
+              >
+                {saving ? 'Saving…' : 'Save Policy'}
+              </button>
+            </div>
+          </div>
+
+          {saveError && (
+            <div style={{ background: 'rgba(255,80,80,0.08)', border: '1px solid rgba(255,80,80,0.2)', borderRadius: '8px', padding: '10px 14px' }}>
+              <p style={{ margin: 0, fontFamily: 'JetBrains Mono, monospace', fontSize: '11px', color: '#ff5050' }}>{saveError}</p>
+            </div>
+          )}
+
+          <textarea
+            value={draft}
+            onChange={e => handleDraftChange(e.target.value)}
+            disabled={!domainID || loading}
+            placeholder={loading ? 'Loading policy…' : '{\n  "platform": "snp",\n  "measurements": {}\n}'}
+            spellCheck={false}
+            style={{
+              flex: 1,
+              minHeight: '400px',
+              background: 'var(--card-bg)',
+              border: `1px solid ${parseError ? 'rgba(255,80,80,0.4)' : 'var(--border)'}`,
+              borderRadius: '10px',
+              color: 'var(--text)',
+              fontFamily: 'JetBrains Mono, monospace',
+              fontSize: '12px',
+              lineHeight: '1.6',
+              padding: '16px',
+              resize: 'vertical',
+              outline: 'none',
+              transition: 'border-color 0.12s ease',
+            }}
+          />
+        </div>
+
+        {/* Right — info panel */}
+        <div style={{ width: '280px', flexShrink: 0, display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          <InfoCard title="What is Attestation?">
+            <p style={{ margin: 0, fontFamily: 'Space Grotesk, sans-serif', fontSize: '13px', color: 'var(--text-muted)', lineHeight: 1.6 }}>
+              Attestation (aTLS) verifies that the Cube agent is running inside a trusted
+              Confidential Computing environment — AMD SEV-SNP, Intel TDX, or Azure CVM —
+              before any data is processed.
+            </p>
+          </InfoCard>
+
+          <InfoCard title="Policy Format">
+            <p style={{ margin: '0 0 8px', fontFamily: 'Space Grotesk, sans-serif', fontSize: '13px', color: 'var(--text-muted)', lineHeight: 1.6 }}>
+              The policy is stored as JSON. Supported platforms:
+            </p>
+            <ul style={{ margin: 0, padding: '0 0 0 16px', fontFamily: 'JetBrains Mono, monospace', fontSize: '11px', color: 'var(--text-dim)', lineHeight: 1.8 }}>
+              <li>snp — AMD SEV-SNP</li>
+              <li>tdx — Intel TDX</li>
+              <li>snp_vtpm — SNP + vTPM</li>
+              <li>azure — Azure CVM</li>
+              <li>no_cc — No CC (dev/test)</li>
+            </ul>
+          </InfoCard>
+
+          <InfoCard title="How It Works">
+            <p style={{ margin: 0, fontFamily: 'Space Grotesk, sans-serif', fontSize: '13px', color: 'var(--text-muted)', lineHeight: 1.6 }}>
+              When a request reaches the proxy, the router matches it against the
+              <code style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '11px', background: 'rgba(255,255,255,0.07)', padding: '1px 5px', borderRadius: '4px' }}> attestation </code>
+              route. The proxy establishes an aTLS handshake with the agent and verifies the
+              hardware attestation report before forwarding. Results are captured in Audit Logs.
+            </p>
+          </InfoCard>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -49,6 +49,15 @@ export default defineConfig({
         target: process.env['EMBEDDER_PROXY_TARGET'] ?? 'http://localhost:8082',
         changeOrigin: true,
       },
+      // Cube Proxy: domain-scoped attestation and agent routes.
+      // Only active in dev when CUBE_PROXY_TARGET is set.
+      ...(process.env['CUBE_PROXY_TARGET'] ? {
+        '/attestation': {
+          target: process.env['CUBE_PROXY_TARGET'],
+          changeOrigin: true,
+          secure: false,
+        },
+      } : {}),
     },
   },
 })

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -49,15 +49,6 @@ export default defineConfig({
         target: process.env['EMBEDDER_PROXY_TARGET'] ?? 'http://localhost:8082',
         changeOrigin: true,
       },
-      // Cube Proxy: domain-scoped attestation and agent routes.
-      // Only active in dev when CUBE_PROXY_TARGET is set.
-      ...(process.env['CUBE_PROXY_TARGET'] ? {
-        '/attestation': {
-          target: process.env['CUBE_PROXY_TARGET'],
-          changeOrigin: true,
-          secure: false,
-        },
-      } : {}),
     },
   },
 })


### PR DESCRIPTION
<!--
Copyright (c) Ultraviolet
SPDX-License-Identifier: Apache-2.0
-->

<!--

Pull request title should be `UV-XXX - description` or `COCOS-XXX - description` or `NOISSUE - description` where XXX is the ID of the issue that this PR relate to. Please review the [CONTRIBUTING.md](https://github.com/ultravioletrs/.github/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

Please avoid force-pushing additional commits for a timely review/response if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits.
- Update any related documentation.
-->

# What type of PR is this?

This is a feature because it adds the Attestation page to the Cube UI and adds no-policy response handling to the cube-proxy.

## What does this do?

- Adds an optional Attestation page to the Vite UI, gated behind the `VITE_ENABLE_ATTESTATION=true` build-time flag. When disabled (default), no attestation nav item, route, or API calls are included in the bundle.
- The page lets domain members view and update the aTLS attestation policy via a JSON editor with Refresh and Save actions.
- API calls route through `/proxy/*` so the existing Vite dev proxy and Traefik setup work without extra configuration.
- Fixes cube-proxy returning 403 instead of an empty 200 when no attestation policy exists in the database yet.

## Which issue(s) does this PR fix/relate to?

No issue.

## Have you included tests for your changes?

No. The attestation page is UI-only and the proxy change (`sql.ErrNoRows` → empty response) is a one-line guard with no testable business logic beyond the existing DB layer.

## Did you document any new/modified features?

The `ui/.env.example` documents the `VITE_ENABLE_ATTESTATION` flag and the existing `agent/workflows/attestation-policy.md` covers the full policy generation workflow.

### Notes

Policy generation requires real TEE hardware (AMD SEV-SNP, Intel TDX, GCP, or Azure CVM) and `cocos-cli`. For local dev, setting `VITE_ENABLE_ATTESTATION=true` and uploading `{"platform":"no_cc"}` via the editor is sufficient to exercise the full Save/Refresh flow.