### PR TITLE
NOISSUE - Add filename-aware retrieval

### DIFF
--- a/internal/embedder/postgres/chunks_search.go
+++ b/internal/embedder/postgres/chunks_search.go
@@ -60,14 +60,40 @@ func (r *ChunksRepository) KeywordSearchChunks(
 		}
 	}
 
-	likeExprs := make([]string, 0, len(terms))
-	rankExprs := make([]string, 0, len(terms))
+	metadataTerms := metadataSearchTerms(terms)
+	likeExprs := make([]string, 0, len(terms)+len(metadataTerms))
+	rankExprs := make([]string, 0, len(terms)+len(metadataTerms))
 	for _, term := range terms {
 		ph := fmt.Sprintf("$%d", next)
 		next++
 		args = append(args, "%"+term+"%")
 		likeExprs = append(likeExprs, "c.content ILIKE "+ph)
 		rankExprs = append(rankExprs, "CASE WHEN c.content ILIKE "+ph+" THEN 1 ELSE 0 END")
+	}
+	for _, term := range metadataTerms {
+		ph := fmt.Sprintf("$%d", next)
+		next++
+		args = append(args, "%"+term+"%")
+		likeExprs = append(likeExprs,
+			"r.name ILIKE "+ph,
+			"COALESCE(r.description, '') ILIKE "+ph,
+			"COALESCE(r.external_ref, '') ILIKE "+ph,
+			"COALESCE(r.external_url, '') ILIKE "+ph,
+			"COALESCE(r.mime_type, '') ILIKE "+ph,
+			"r.format ILIKE "+ph,
+			"COALESCE(s.name, '') ILIKE "+ph,
+			"s.source_type::text ILIKE "+ph,
+		)
+		rankExprs = append(rankExprs,
+			"CASE WHEN r.name ILIKE "+ph+" THEN 4 ELSE 0 END",
+			"CASE WHEN COALESCE(r.description, '') ILIKE "+ph+" THEN 2 ELSE 0 END",
+			"CASE WHEN COALESCE(r.external_ref, '') ILIKE "+ph+" THEN 1 ELSE 0 END",
+			"CASE WHEN COALESCE(r.external_url, '') ILIKE "+ph+" THEN 1 ELSE 0 END",
+			"CASE WHEN COALESCE(r.mime_type, '') ILIKE "+ph+" THEN 1 ELSE 0 END",
+			"CASE WHEN r.format ILIKE "+ph+" THEN 1 ELSE 0 END",
+			"CASE WHEN COALESCE(s.name, '') ILIKE "+ph+" THEN 2 ELSE 0 END",
+			"CASE WHEN s.source_type::text ILIKE "+ph+" THEN 1 ELSE 0 END",
+		)
 	}
 	where = append(where, "("+strings.Join(likeExprs, " OR ")+")")
 
@@ -219,11 +245,15 @@ keyword_ranked AS (
           AND rec.status = 'indexed'
           AND to_tsvector('english', c.content) @@ websearch_to_tsquery('english', ` + queryPH + `)`)
 		sb.WriteString(recordIDFilter)
+		metadataTerms := metadataSearchTerms(terms)
+
 		sb.WriteString(`
         ORDER BY fts_rank DESC
         LIMIT $3
     ) t
-),
+ )`)
+		if len(metadataTerms) == 0 {
+			sb.WriteString(`,
 rrf AS (
     SELECT COALESCE(v.id, k.id) AS chunk_id,
            COALESCE(1.0 / (60.0 + v.rank::float), 0.0)
@@ -231,6 +261,66 @@ rrf AS (
     FROM vector_ranked v
     FULL OUTER JOIN keyword_ranked k ON k.id = v.id
 )`)
+		} else {
+			sb.WriteString(`,
+metadata_ranked AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY metadata_score DESC, updated_at DESC, chunk_index ASC) AS rank
+    FROM (
+        SELECT c.id, rec.updated_at, c.chunk_index,
+               `)
+
+			metadataRankExprs := make([]string, 0, len(metadataTerms)*8)
+			metadataLikeExprs := make([]string, 0, len(metadataTerms)*8)
+			for _, term := range metadataTerms {
+				ph := fmt.Sprintf("$%d", next)
+				next++
+				args = append(args, "%"+strings.ToLower(term)+"%")
+				metadataRankExprs = append(metadataRankExprs,
+					"CASE WHEN lower(rec.name) LIKE "+ph+" THEN 4 ELSE 0 END",
+					"CASE WHEN lower(COALESCE(rec.description, '')) LIKE "+ph+" THEN 2 ELSE 0 END",
+					"CASE WHEN lower(COALESCE(rec.external_ref, '')) LIKE "+ph+" THEN 1 ELSE 0 END",
+					"CASE WHEN lower(COALESCE(rec.external_url, '')) LIKE "+ph+" THEN 1 ELSE 0 END",
+					"CASE WHEN lower(COALESCE(rec.mime_type, '')) LIKE "+ph+" THEN 1 ELSE 0 END",
+					"CASE WHEN lower(rec.format) LIKE "+ph+" THEN 1 ELSE 0 END",
+					"CASE WHEN lower(COALESCE(s.name, '')) LIKE "+ph+" THEN 2 ELSE 0 END",
+					"CASE WHEN lower(s.source_type::text) LIKE "+ph+" THEN 1 ELSE 0 END",
+				)
+				metadataLikeExprs = append(metadataLikeExprs,
+					"lower(rec.name) LIKE "+ph,
+					"lower(COALESCE(rec.description, '')) LIKE "+ph,
+					"lower(COALESCE(rec.external_ref, '')) LIKE "+ph,
+					"lower(COALESCE(rec.external_url, '')) LIKE "+ph,
+					"lower(COALESCE(rec.mime_type, '')) LIKE "+ph,
+					"lower(rec.format) LIKE "+ph,
+					"lower(COALESCE(s.name, '')) LIKE "+ph,
+					"lower(s.source_type::text) LIKE "+ph,
+				)
+			}
+
+			sb.WriteString(strings.Join(metadataRankExprs, " + "))
+			sb.WriteString(` AS metadata_score
+        FROM chunks c
+        JOIN records rec ON rec.id = c.record_id
+        LEFT JOIN sources s ON s.id = rec.source_id
+        WHERE c.domain_id = $1
+          AND rec.status = 'indexed'
+          AND (` + strings.Join(metadataLikeExprs, " OR ") + `)`)
+			sb.WriteString(recordIDFilter)
+			sb.WriteString(`
+        ORDER BY metadata_score DESC, rec.updated_at DESC, c.chunk_index ASC
+        LIMIT $3
+    ) t
+),
+rrf AS (
+    SELECT COALESCE(v.id, k.id, m.id) AS chunk_id,
+           COALESCE(1.0 / (60.0 + v.rank::float), 0.0)
+         + COALESCE(1.0 / (60.0 + k.rank::float), 0.0)
+         + COALESCE(3.0 / (20.0 + m.rank::float), 0.0) AS score
+    FROM vector_ranked v
+    FULL OUTER JOIN keyword_ranked k ON k.id = v.id
+    FULL OUTER JOIN metadata_ranked m ON m.id = COALESCE(v.id, k.id)
+)`)
+		}
 	}
 
 	topKPH := fmt.Sprintf("$%d", next)
@@ -287,4 +377,32 @@ func searchTerms(query string) []string {
 		}
 	}
 	return terms
+}
+
+func metadataSearchTerms(terms []string) []string {
+	seen := make(map[string]struct{}, len(terms)*2)
+	out := make([]string, 0, len(terms)*2)
+	for _, term := range terms {
+		term = strings.ToLower(strings.TrimSpace(term))
+		if len(term) < 3 {
+			continue
+		}
+		addSearchTerm(&out, seen, term)
+		if len(term) >= 5 {
+			addSearchTerm(&out, seen, strings.TrimRight(term, "aeiou"))
+			addSearchTerm(&out, seen, strings.TrimSuffix(term, "s"))
+		}
+	}
+	return out
+}
+
+func addSearchTerm(terms *[]string, seen map[string]struct{}, term string) {
+	if len(term) < 3 {
+		return
+	}
+	if _, ok := seen[term]; ok {
+		return
+	}
+	seen[term] = struct{}{}
+	*terms = append(*terms, term)
 }


### PR DESCRIPTION
# What type of PR is this?

  This is a feature/improvement because it improves retrieval quality for user queries that match document filenames or safe record/source metadata.

  ## What does this do?

  This PR adds filename-aware and metadata-aware retrieval to chunk search.

  Changes included:
  - Extends keyword chunk search to match against record filenames in addition to chunk content.
  - Extends hybrid retrieval with a metadata-ranked retrieval path combined through RRF.
  - Boosts matches from `record.name` so files can be found by filename terms such as `mart` in `odrzavanje_mart_2026.pdf`.
  - Adds safe metadata matching for:
    - record description
    - external ref
    - external URL
    - MIME type
    - record format
    - source name
    - source type
  - Avoids searching `sources.config` because it may contain credentials, OAuth configuration, or noisy implementation details.
  - Adds small term normalization for metadata lookup, including simple suffix/plural fallback for English terms.

  This improves cases where the relevant document is identifiable by filename or metadata even when the exact query term is not strongly represented in the embedded chunk
  text.

  ## Which issue(s) does this PR fix/relate to?

  No linked issue.

## Have you included tests for your changes?

  No new tests were added.

  Manual verification was performed through the UI by querying a filename term (`mart`) and confirming that `odrzavanje_mart_2026.pdf` is returned in the retrieval context.

  Existing relevant backend tests were run successfully:

  `go test ./internal/embedder/postgres ./internal/embedder/service ./internal/embedder/ingest`

  ## Did you document any new/modified features?

  No documentation was updated.

  The change is backend retrieval behavior and does not introduce a new user-facing configuration option.

  ### Notes

  This PR focuses only on retrieval ranking/search behavior. Follow-up improvements such as better answer wording for short filename-style queries and domains page loading
  performance should be handled separately.
