### PR TITLE
NOISSUE - Improve rag answer behavior

### DIFF
--- a/internal/embedder/service/chat.go
+++ b/internal/embedder/service/chat.go
@@ -23,6 +23,14 @@ type chatService struct {
 	factory    llm.ClientFactory // builds a client from a per-request config
 }
 
+const ragSystemPrompt = `You are a retrieval-grounded assistant.
+When document excerpts are provided, answer from those excerpts first and avoid inventing information.
+When the user's intent is unclear, consider both the retrieved document context and the possible general meaning of the query. Clearly distinguish what the records show from general knowledge, and ask a concise follow-up question when needed.
+For short keywords, filename fragments, dates, or codes, mention relevant record names naturally when they help answer the question.
+Use direct phrasing such as "I found this in <record name>" or "The relevant record is <record name>". Do not say "the matched record name for the query".
+If the excerpts do not contain enough information to answer the user's intent, say what was found and ask a concise follow-up question.
+Cite relevant excerpt numbers when making factual claims.`
+
 // NewChatService returns a ChatService that retrieves context chunks then
 // streams the LLM response.  reranker may be nil to skip re-ranking.
 // factory is called to build a temporary client when the request overrides
@@ -61,7 +69,6 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 			break
 		}
 	}
-
 	var citations []domain.Citation
 	var chunks []domain.VectorChunk
 	var retrievalWarning string
@@ -102,10 +109,16 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 		// On reranker error, keep the RRF order — non-fatal.
 	}
 
+	slog.Info("chat: prepared rag context",
+		"retrieval_query_chars", len(query),
+		"retrieved_chunks", len(chunks),
+		"prompt_chunks", len(chunks),
+	)
+
 	// Build citation list.
 	var contextBlock strings.Builder
 	for i, c := range chunks {
-		contextBlock.WriteString(fmt.Sprintf("[%d] %s:\n%s\n\n", i+1, c.RecordName, c.Content))
+		contextBlock.WriteString(fmt.Sprintf("[%d] Record: %s\nExcerpt:\n%s\n\n", i+1, c.RecordName, c.Content))
 		citations = append(citations, domain.Citation{
 			RecordID:    c.RecordID,
 			RecordName:  c.RecordName,
@@ -122,7 +135,7 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 	llmMessages := make([]llm.Message, 0, len(messages)+1)
 	llmMessages = append(llmMessages, llm.Message{
 		Role:    "system",
-		Content: "You are a helpful, knowledgeable assistant. When document excerpts are provided, use them as your primary source and cite them, but also use your general knowledge to give complete, thorough answers.",
+		Content: ragSystemPrompt,
 	})
 	if contextBlock.Len() > 0 {
 		// RAG mode: only send the last user message augmented with context.
@@ -132,8 +145,11 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 			if messages[i].Role == "user" {
 				llmMessages = append(llmMessages, llm.Message{
 					Role: "user",
-					Content: "Use the following document excerpts to inform your answer. " +
-						"Cite relevant excerpts, then elaborate with a complete and thorough explanation.\n\n" +
+					Content: "Use the following retrieved records and excerpts to answer the question. " +
+						"Mention relevant record names naturally when they help answer the question. " +
+						"Prefer direct phrasing like \"I found this in <record name>\". " +
+						"Clearly distinguish information found in the records from general knowledge.\n\n" +
+						"MATCHED RECORDS:\n" + matchedRecordsBlock(chunks) + "\n" +
 						"EXCERPTS:\n" + contextBlock.String() +
 						"QUESTION: " + messages[i].Content,
 				})
@@ -203,6 +219,28 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 	}()
 
 	return out, nil
+}
+
+func matchedRecordsBlock(chunks []domain.VectorChunk) string {
+	if len(chunks) == 0 {
+		return ""
+	}
+	seen := make(map[string]struct{}, len(chunks))
+	var b strings.Builder
+	for _, c := range chunks {
+		name := strings.TrimSpace(c.RecordName)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		b.WriteString("- ")
+		b.WriteString(name)
+		b.WriteByte('\n')
+	}
+	return b.String()
 }
 
 func truncate(s string, n int) string {

--- a/internal/embedder/service/chat_test.go
+++ b/internal/embedder/service/chat_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Ultraviolet
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ultravioletrs/cube/internal/embedder/domain"
+)
+
+func TestMatchedRecordsBlockDeduplicatesRecordNames(t *testing.T) {
+	got := matchedRecordsBlock([]domain.VectorChunk{
+		{RecordName: "odrzavanje_mart_2026.pdf"},
+		{RecordName: "odrzavanje_mart_2026.pdf"},
+		{RecordName: "DusanEUCNC.pdf"},
+		{RecordName: " "},
+	})
+
+	want := "- odrzavanje_mart_2026.pdf\n- DusanEUCNC.pdf\n"
+	if got != want {
+		t.Fatalf("unexpected records block:\nwant %q\ngot  %q", want, got)
+	}
+}
+
+func TestRAGSystemPromptGuidesShortQueries(t *testing.T) {
+	for _, phrase := range []string{
+		"consider both the retrieved document context and the possible general meaning",
+		"mention relevant record names naturally",
+		`I found this in <record name>`,
+	} {
+		if !strings.Contains(ragSystemPrompt, phrase) {
+			t.Fatalf("system prompt missing %q", phrase)
+		}
+	}
+}

--- a/internal/embedder/service/chat_test.go
+++ b/internal/embedder/service/chat_test.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/ultravioletrs/cube/internal/embedder/domain"
@@ -21,17 +20,5 @@ func TestMatchedRecordsBlockDeduplicatesRecordNames(t *testing.T) {
 	want := "- odrzavanje_mart_2026.pdf\n- DusanEUCNC.pdf\n"
 	if got != want {
 		t.Fatalf("unexpected records block:\nwant %q\ngot  %q", want, got)
-	}
-}
-
-func TestRAGSystemPromptGuidesShortQueries(t *testing.T) {
-	for _, phrase := range []string{
-		"consider both the retrieved document context and the possible general meaning",
-		"mention relevant record names naturally",
-		`I found this in <record name>`,
-	} {
-		if !strings.Contains(ragSystemPrompt, phrase) {
-			t.Fatalf("system prompt missing %q", phrase)
-		}
 	}
 }


### PR DESCRIPTION
# What type of PR is this?

This is a bug fix that improves retrieval-grounded chat responses.

## What does this do?

  - Provides the model with an explicit, deduplicated list of matched record names.
  - Formats retrieved excerpts with clearer record and excerpt labels.
  - Instructs the model to naturally mention relevant record names.
  - Clearly distinguishes information found in records from general knowledge.
  - Improves responses for short or ambiguous queries without forcing a single interpretation.
  - Adds retrieval context metrics to logs.
  - Preserves the existing number and complete content of retrieved excerpts.

## Which issue(s) does this PR fix/relate to?

NOISSUE

## Have you included tests for your changes?

Yes. A deterministic unit test verifies that matched record names are deduplicated before being provided to the model.

## Did you document any new/modified features?

No. This changes internal RAG prompt construction and does not introduce new user-facing configuration.

### Notes

This PR does not implement conversation-aware retrieval for follow-up questions. It only improves how the model receives and presents the records retrieved for the current
query.
