### PR TITLE
NOISSUE - Add chat intent guard

### DIFF
--- a/internal/embedder/service/chat.go
+++ b/internal/embedder/service/chat.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/ultravioletrs/cube/internal/embedder/domain"
 	"github.com/ultravioletrs/cube/internal/embedder/llm"
@@ -30,6 +31,32 @@ For short keywords, filename fragments, dates, or codes, mention relevant record
 Use direct phrasing such as "I found this in <record name>" or "The relevant record is <record name>". Do not say "the matched record name for the query".
 If the excerpts do not contain enough information to answer the user's intent, say what was found and ask a concise follow-up question.
 Cite relevant excerpt numbers when making factual claims.`
+
+const conversationSystemPrompt = `You are a helpful assistant.
+Respond naturally to conversational messages.
+Do not claim to have searched, found, or used records when no document excerpts are provided.`
+
+var conversationalMessages = map[string]struct{}{
+	"good afternoon":  {},
+	"good evening":    {},
+	"good morning":    {},
+	"goodbye":         {},
+	"got it":          {},
+	"hello":           {},
+	"hi":              {},
+	"hi there":        {},
+	"how are you":     {},
+	"hey":             {},
+	"ok":              {},
+	"okay":            {},
+	"see you":         {},
+	"thank you":       {},
+	"thanks":          {},
+	"thanks a lot":    {},
+	"understood":      {},
+	"you are welcome": {},
+	"you're welcome":  {},
+}
 
 // NewChatService returns a ChatService that retrieves context chunks then
 // streams the LLM response.  reranker may be nil to skip re-ranking.
@@ -72,8 +99,9 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 	var citations []domain.Citation
 	var chunks []domain.VectorChunk
 	var retrievalWarning string
+	retrieveForQuery := shouldRetrieve(query)
 
-	if query != "" {
+	if retrieveForQuery {
 		var err error
 		chunks, err = s.retrieve.Retrieve(ctx, domainID, query, recordIDs, s.topK)
 		if err != nil {
@@ -82,6 +110,9 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 		} else if len(chunks) == 0 {
 			retrievalWarning = "No relevant chunks found in indexed records — answering without document context."
 		}
+	}
+	if !retrieveForQuery {
+		slog.Info("chat: skipped retrieval for conversational message")
 	}
 
 	// Re-rank if we have a reranker and more than one chunk to order.
@@ -133,9 +164,13 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 	// message and drop stale history so small models (e.g. llama3.2:3b) are not
 	// confused by prior wrong answers or an oversized context window.
 	llmMessages := make([]llm.Message, 0, len(messages)+1)
+	systemPrompt := ragSystemPrompt
+	if !retrieveForQuery {
+		systemPrompt = conversationSystemPrompt
+	}
 	llmMessages = append(llmMessages, llm.Message{
 		Role:    "system",
-		Content: ragSystemPrompt,
+		Content: systemPrompt,
 	})
 	if contextBlock.Len() > 0 {
 		// RAG mode: only send the last user message augmented with context.
@@ -219,6 +254,19 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 	}()
 
 	return out, nil
+}
+
+func shouldRetrieve(query string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(query))
+	normalized = strings.TrimFunc(normalized, func(r rune) bool {
+		return unicode.IsPunct(r) || unicode.IsSpace(r)
+	})
+	normalized = strings.Join(strings.Fields(normalized), " ")
+	if normalized == "" {
+		return false
+	}
+	_, conversational := conversationalMessages[normalized]
+	return !conversational
 }
 
 func matchedRecordsBlock(chunks []domain.VectorChunk) string {

--- a/internal/embedder/service/chat_test.go
+++ b/internal/embedder/service/chat_test.go
@@ -4,10 +4,77 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ultravioletrs/cube/internal/embedder/domain"
+	"github.com/ultravioletrs/cube/internal/embedder/llm"
 )
+
+type chatRetrieveStub struct {
+	calls int
+}
+
+func (s *chatRetrieveStub) Retrieve(context.Context, string, string, []string, int) ([]domain.VectorChunk, error) {
+	s.calls++
+	return nil, nil
+}
+
+type chatLLMStub struct {
+	messages []llm.Message
+}
+
+func (s *chatLLMStub) StreamChat(_ context.Context, messages []llm.Message, out chan<- string) error {
+	s.messages = messages
+	close(out)
+	return nil
+}
+
+func TestShouldRetrieveOnlySkipsClearConversationalMessages(t *testing.T) {
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{query: "hello", want: false},
+		{query: "  THANK YOU! ", want: false},
+		{query: "how are you?", want: false},
+		{query: "", want: false},
+		{query: "mart", want: true},
+		{query: "Dusan", want: true},
+		{query: "hello Dusan", want: true},
+		{query: "thanks from Dusan", want: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.query, func(t *testing.T) {
+			if got := shouldRetrieve(test.query); got != test.want {
+				t.Fatalf("shouldRetrieve(%q) = %v, want %v", test.query, got, test.want)
+			}
+		})
+	}
+}
+
+func TestChatSkipsRetrievalForConversationalMessage(t *testing.T) {
+	retrieve := &chatRetrieveStub{}
+	client := &chatLLMStub{}
+	service := NewChatService(retrieve, client, nil, 8, llm.Config{}, nil)
+
+	events, err := service.Chat(context.Background(), "domain", []domain.ChatMessage{
+		{Role: "user", Content: "hello!"},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("chat failed: %v", err)
+	}
+	for range events {
+	}
+
+	if retrieve.calls != 0 {
+		t.Fatalf("expected retrieval to be skipped, got %d calls", retrieve.calls)
+	}
+	if len(client.messages) == 0 || client.messages[0].Content != conversationSystemPrompt {
+		t.Fatal("expected conversational system prompt")
+	}
+}
 
 func TestMatchedRecordsBlockDeduplicatesRecordNames(t *testing.T) {
 	got := matchedRecordsBlock([]domain.VectorChunk{


### PR DESCRIPTION
# What type of PR is this?

This is an optimization and bug fix for chat retrieval behavior.

## What does this do?

  - Skips document retrieval for clear conversational messages such as greetings, thanks, acknowledgements, and goodbyes.
  - Uses a dedicated conversational system prompt when retrieval is skipped.
  - Prevents the assistant from claiming it searched or found records when no retrieval occurred.
  - Normalizes casing, whitespace, and punctuation before classifying messages.
  - Keeps retrieval enabled for possible document queries such as mart, Dusan, hello Dusan, and other messages containing additional terms.
  - Reduces unnecessary embedding, retrieval, and reranking operations.

No existing document retrieval functionality is intentionally removed.

## Which issue(s) does this PR fix/relate to?

NOISSUE

## Have you included tests for your changes?

Yes. Tests verify that clear conversational messages skip retrieval, while possible document queries continue using retrieval. They also verify that the conversational
system prompt is used when retrieval is skipped.

## Did you document any new/modified features?

No. This changes internal chat retrieval behavior and does not introduce new user-facing configuration.

### Notes

The intent guard is intentionally conservative. It only skips retrieval for a limited set of clear conversational messages to avoid incorrectly blocking short or ambiguous
document searches.
