### PR TITLE
NOISSUE - Add model provider connection test

### DIFF
--- a/docker/traefik/dynamic.toml
+++ b/docker/traefik/dynamic.toml
@@ -65,6 +65,15 @@
     interval = "10s"
     timeout = "10s"
 
+[http.services.embedder.loadBalancer]
+  [[http.services.embedder.loadBalancer.servers]]
+    url = "http://cube-embedder:8082"
+  [http.services.embedder.loadBalancer.healthCheck]
+    scheme = "http"
+    path = "/health"
+    interval = "10s"
+    timeout = "10s"
+
 [http.services.domains.loadBalancer]
   [[http.services.domains.loadBalancer.servers]]
     url = "http://supermq-domains:9003"
@@ -161,8 +170,15 @@
   middlewares = ["retry-middleware", "headers-middleware"]
   priority = 9
 
+[http.routers.embedder]
+  rule = "PathPrefix(`/api`)"
+  entryPoints = ["websecure"]
+  service = "embedder"
+  middlewares = ["retry-middleware", "headers-middleware"]
+  priority = 8
+
 [http.routers.ui]
-  rule = "PathPrefix(`/`) || PathPrefix(`/api`)"
+  rule = "PathPrefix(`/`)"
   entryPoints = ["websecure"]
   service = "ui"
   middlewares = ["retry-middleware", "headers-middleware"]

--- a/internal/embedder/api/http.go
+++ b/internal/embedder/api/http.go
@@ -51,6 +51,7 @@ func NewRouter(
 		transport.MountChat(r, chatSvc, conversationsRepo)
 		transport.MountConversations(r, conversationsRepo)
 		transport.MountGuardrails(r, guardrailsCtrl)
+		transport.MountModelConnection(r, ollamaBaseURL)
 	})
 
 	return r

--- a/internal/embedder/api/transport/models.go
+++ b/internal/embedder/api/transport/models.go
@@ -4,9 +4,13 @@
 package transport
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -14,6 +18,11 @@ import (
 // MountModels registers model-listing endpoints.
 func MountModels(r chi.Router, ollamaBaseURL string) {
 	r.Get("/api/v1/models/ollama", listOllamaModelsHandler(ollamaBaseURL))
+}
+
+// MountModelConnection registers the authenticated provider connection test.
+func MountModelConnection(r chi.Router, ollamaBaseURL string) {
+	r.Post("/api/v1/models/test-connection", testModelConnectionHandler(ollamaBaseURL))
 }
 
 type ollamaTagsResponse struct {
@@ -49,4 +58,148 @@ func listOllamaModelsHandler(baseURL string) http.HandlerFunc {
 
 		writeJSON(w, http.StatusOK, map[string]any{"models": names})
 	}
+}
+
+type modelConnectionRequest struct {
+	Provider string `json:"provider"`
+	BaseURL  string `json:"base_url"`
+	Model    string `json:"model"`
+	APIKey   string `json:"api_key"`
+}
+
+type modelConnectionResponse struct {
+	Connected bool   `json:"connected"`
+	Message   string `json:"message"`
+}
+
+func testModelConnectionHandler(ollamaBaseURL string) http.HandlerFunc {
+	client := &http.Client{Timeout: 20 * time.Second}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req modelConnectionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, errBody("invalid request body"))
+			return
+		}
+
+		req.Provider = strings.ToLower(strings.TrimSpace(req.Provider))
+		req.Model = strings.TrimSpace(req.Model)
+		if req.Model == "" {
+			writeJSON(w, http.StatusBadRequest, errBody("model is required"))
+			return
+		}
+
+		var err error
+		switch req.Provider {
+		case "ollama":
+			err = testOllamaConnection(r.Context(), client, ollamaBaseURL, req.Model)
+		case "openai":
+			err = testOpenAICompatibleConnection(r.Context(), client, req.BaseURL, req.Model, req.APIKey)
+		default:
+			writeJSON(w, http.StatusBadRequest, errBody("unsupported provider"))
+			return
+		}
+		if err != nil {
+			writeJSON(w, http.StatusOK, modelConnectionResponse{Connected: false, Message: err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, modelConnectionResponse{Connected: true, Message: "Connection successful"})
+	}
+}
+
+func testOllamaConnection(ctx context.Context, client *http.Client, baseURL, model string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/api/tags", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return contextError("Ollama unavailable", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return statusError("Ollama unavailable", resp.StatusCode)
+	}
+
+	var tags ollamaTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return contextError("Invalid Ollama response", err)
+	}
+	for _, available := range tags.Models {
+		if available.Name == model {
+			return nil
+		}
+	}
+	return &connectionError{message: "Model is not available in Ollama"}
+}
+
+func testOpenAICompatibleConnection(ctx context.Context, client *http.Client, baseURL, model, apiKey string) error {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if !allowedExternalModelURL(baseURL) {
+		return &connectionError{message: "Provider URL is not allowed"}
+	}
+	if strings.TrimSpace(apiKey) == "" {
+		return &connectionError{message: "API key is required"}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"model":      model,
+		"messages":   []map[string]string{{"role": "user", "content": "Reply OK"}},
+		"max_tokens": 1,
+	})
+	if err != nil {
+		return contextError("Could not build provider request", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return contextError("Could not build provider request", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return contextError("Provider unavailable", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return &connectionError{message: "Invalid API key or insufficient permissions"}
+		case http.StatusNotFound:
+			return &connectionError{message: "Model or provider endpoint not found"}
+		default:
+			return statusError("Provider rejected the connection test", resp.StatusCode)
+		}
+	}
+	return nil
+}
+
+func allowedExternalModelURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.Path != "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return false
+	}
+	switch parsed.Host {
+	case "api.openai.com", "api.anthropic.com":
+		return true
+	default:
+		return false
+	}
+}
+
+type connectionError struct {
+	message string
+}
+
+func (e *connectionError) Error() string {
+	return e.message
+}
+
+func contextError(message string, _ error) error {
+	return &connectionError{message: message}
+}
+
+func statusError(message string, status int) error {
+	return &connectionError{message: message + " (HTTP " + http.StatusText(status) + ")"}
 }

--- a/internal/embedder/api/transport/models_test.go
+++ b/internal/embedder/api/transport/models_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) Ultraviolet
+// SPDX-License-Identifier: Apache-2.0
+
+package transport
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOllamaConnectionChecksSelectedModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"models":[{"name":"llama3.2:3b"}]}`)
+	}))
+	defer server.Close()
+
+	if err := testOllamaConnection(context.Background(), server.Client(), server.URL, "llama3.2:3b"); err != nil {
+		t.Fatalf("expected model connection to succeed: %v", err)
+	}
+	if err := testOllamaConnection(context.Background(), server.Client(), server.URL, "missing"); err == nil || err.Error() != "Model is not available in Ollama" {
+		t.Fatalf("expected missing model error, got %v", err)
+	}
+}
+
+func TestAllowedExternalModelURL(t *testing.T) {
+	for _, allowed := range []string{"https://api.openai.com", "https://api.anthropic.com"} {
+		if !allowedExternalModelURL(allowed) {
+			t.Fatalf("expected %q to be allowed", allowed)
+		}
+	}
+	for _, blocked := range []string{
+		"http://api.openai.com",
+		"https://api.openai.com/v1",
+		"https://example.com",
+		"https://api.openai.com?key=secret",
+	} {
+		if allowedExternalModelURL(blocked) {
+			t.Fatalf("expected %q to be blocked", blocked)
+		}
+	}
+}
+
+func TestOpenAIConnectionDoesNotExposeProviderResponse(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("Authorization"); got != "Bearer secret-key" {
+			t.Fatalf("unexpected authorization header %q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"provider secret response"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+
+	err := testOpenAICompatibleConnection(context.Background(), client, "https://api.openai.com", "gpt-4o-mini", "secret-key")
+	if err == nil {
+		t.Fatal("expected connection test to fail")
+	}
+	if strings.Contains(err.Error(), "provider secret response") || strings.Contains(err.Error(), "secret-key") {
+		t.Fatalf("connection error exposed sensitive provider data: %v", err)
+	}
+	if err.Error() != "Invalid API key or insufficient permissions" {
+		t.Fatalf("unexpected connection error: %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -156,6 +156,27 @@ export async function listOllamaModels(token: string, domainID: string): Promise
   return data.models ?? []
 }
 
+export interface ModelConnectionResult {
+  connected: boolean
+  message: string
+}
+
+export async function testModelConnection(
+  token: string,
+  config: BackendModelConfig,
+): Promise<ModelConnectionResult> {
+  const res = await fetch('/api/v1/models/test-connection', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(config),
+  })
+  if (!res.ok) {
+    const body = await res.json().catch(() => null) as { error?: string } | null
+    throw new Error(body?.error || `model connection test: ${res.status}`)
+  }
+  return res.json() as Promise<ModelConnectionResult>
+}
+
 export interface GuardrailsStatus {
   enabled: boolean
   configured: boolean

--- a/ui/src/pages/ConfigPage.tsx
+++ b/ui/src/pages/ConfigPage.tsx
@@ -3,9 +3,9 @@
 import { useState, useEffect } from 'react'
 import UserMenu from '@/components/UserMenu'
 import { useAuth } from '@/hooks/useAuth'
-import { loadModelConfig, saveModelConfig, DEFAULT_MODEL_CONFIG, LLM_MODEL_OPTIONS } from '@/lib/modelConfig'
+import { loadModelConfig, saveModelConfig, DEFAULT_MODEL_CONFIG, LLM_MODEL_OPTIONS, toBackendModelConfig } from '@/lib/modelConfig'
 import type { LLMProvider } from '@/lib/modelConfig'
-import { getGuardrailsStatus, listOllamaModels, setGuardrailsEnabled } from '@/lib/api'
+import { getGuardrailsStatus, listOllamaModels, setGuardrailsEnabled, testModelConnection } from '@/lib/api'
 
 function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
   return (
@@ -118,6 +118,8 @@ export default function ConfigPage() {
   const [guardrailsEnabled, setGuardrailsEnabledState] = useState(false)
   const [guardrailsConfigured, setGuardrailsConfigured] = useState(false)
   const [guardrailsLoading, setGuardrailsLoading] = useState(false)
+  const [connectionTesting, setConnectionTesting] = useState(false)
+  const [connectionResult, setConnectionResult] = useState<{ connected: boolean; message: string } | null>(null)
 
   useEffect(() => {
     if (!tokens?.accessToken) return
@@ -166,6 +168,7 @@ export default function ConfigPage() {
   const handleProviderChange = (p: string) => {
     const provider = p as LLMProvider
     setLlmProvider(provider)
+    setConnectionResult(null)
     if (provider === 'local') {
       setLlmModel(ollamaModels[0] ?? '')
     } else {
@@ -182,6 +185,20 @@ export default function ConfigPage() {
     saveModelConfig({ provider: llmProvider, model: llmModel, apiKey, temperature, maxTokens, streamResponses, systemPrompt })
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
+  }
+
+  const handleTestConnection = async () => {
+    const config = toBackendModelConfig({ provider: llmProvider, model: llmModel, apiKey, temperature, maxTokens, streamResponses, systemPrompt })
+    if (!config || !accessToken || connectionTesting) return
+    setConnectionTesting(true)
+    setConnectionResult(null)
+    try {
+      setConnectionResult(await testModelConnection(accessToken, config))
+    } catch (err) {
+      setConnectionResult({ connected: false, message: err instanceof Error ? err.message : 'Connection test failed' })
+    } finally {
+      setConnectionTesting(false)
+    }
   }
 
   return (
@@ -206,7 +223,7 @@ export default function ConfigPage() {
             <Field label="Provider"><ProviderButtons providers={['openai', 'anthropic', 'local']} active={llmProvider} onSelect={handleProviderChange} labelMap={providerLabel} /></Field>
             {llmProvider !== 'local' && (
               <Field label="API Key" hint={`Your ${providerLabel[llmProvider]} API key. Stored locally in your browser only.`}>
-                <input type="password" value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder="sk-..." style={{ width: '100%', background: 'rgba(255,255,255,0.04)', border: '1px solid var(--border)', borderRadius: '8px', padding: '9px 12px', color: 'var(--text)', fontFamily: 'JetBrains Mono, monospace', fontSize: '12px', outline: 'none', boxSizing: 'border-box' }} />
+                <input type="password" value={apiKey} onChange={e => { setApiKey(e.target.value); setConnectionResult(null) }} placeholder="sk-..." style={{ width: '100%', background: 'rgba(255,255,255,0.04)', border: '1px solid var(--border)', borderRadius: '8px', padding: '9px 12px', color: 'var(--text)', fontFamily: 'JetBrains Mono, monospace', fontSize: '12px', outline: 'none', boxSizing: 'border-box' }} />
                 {externalProviderMissingKey && (
                   <InlineNotice tone="warning">
                     API key is missing. Chat requests will use the server default model instead of {providerLabel[llmProvider]}.
@@ -217,8 +234,22 @@ export default function ConfigPage() {
             <Field label="Model" hint={llmProvider === 'local' ? 'Models fetched live from your Ollama instance.' : 'The selected model must support function calling for optimal RAG performance.'}>
               {llmProvider === 'local' && ollamaLoading
                 ? <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '11px', color: 'var(--text-dim)', padding: '9px 0' }}>Loading models from Ollama…</div>
-                : <SelectInput value={llmModel} onChange={setLlmModel} options={currentModelOptions} />
+                : <SelectInput value={llmModel} onChange={value => { setLlmModel(value); setConnectionResult(null) }} options={currentModelOptions} />
               }
+              <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginTop: '8px' }}>
+                <button
+                  onClick={() => { void handleTestConnection() }}
+                  disabled={connectionTesting || !toBackendModelConfig({ provider: llmProvider, model: llmModel, apiKey, temperature, maxTokens, streamResponses, systemPrompt })}
+                  style={{ padding: '7px 12px', borderRadius: '7px', border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-muted)', fontFamily: 'Space Grotesk, sans-serif', fontSize: '12px', fontWeight: '600', cursor: connectionTesting ? 'default' : 'pointer', opacity: connectionTesting ? 0.55 : 1 }}
+                >
+                  {connectionTesting ? 'Testing…' : 'Test connection'}
+                </button>
+                {connectionResult && (
+                  <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: connectionResult.connected ? 'var(--accent)' : '#ff5050' }}>
+                    {connectionResult.message}
+                  </span>
+                )}
+              </div>
               {llmProvider === 'local' && !ollamaLoading && ollamaModels.length > 0 && (
                 <InlineNotice tone="success">
                   Ollama connected. {ollamaModels.length} local {ollamaModels.length === 1 ? 'model' : 'models'} available.


### PR DESCRIPTION
# What type of PR is this?

This is a feature that adds model provider connection testing from the Configuration page.

## What does this do?

  - Adds a Test connection action for configured language models.
  - Verifies that the selected Ollama model is available.
  - Verifies OpenAI-compatible provider credentials and model access.
  - Displays clear connection success and failure states.
  - Prevents provider responses and API keys from being exposed in errors.
  - Routes /api requests through Traefik to the embedder service.
  - Keeps external API keys stored only in the browser.

## Which issue(s) does this PR fix/relate to?

  - Related Issue: NOISSUE

## Have you included tests for your changes?

Yes. Backend tests cover Ollama model availability, allowed provider URLs, and sensitive data protection.

The following checks were also completed:

  - go test ./internal/embedder/...
  - npm run build
  - npm run lint
  - npm test -- --run

## Did you document any new/modified features?

No separate documentation was added. The Configuration UI describes the connection testing functionality and displays actionable results.

### Notes

OpenAI connection failure was manually verified using an invalid API key. Ollama successful connection testing was also manually verified.
