### PR TITLE
NOISSUE  - Add retrieval debug panel

### DIFF
--- a/internal/embedder/api/transport/chat.go
+++ b/internal/embedder/api/transport/chat.go
@@ -24,6 +24,7 @@ type chatRequest struct {
 	RecordIDs      []string             `json:"record_ids,omitempty"`
 	ConversationID string               `json:"conversation_id,omitempty"`
 	Model          *domain.ModelConfig  `json:"model,omitempty"`
+	Debug          bool                 `json:"debug,omitempty"`
 }
 
 func chatHandler(svc domain.ChatService, conversations domain.ConversationRepository) http.HandlerFunc {
@@ -59,7 +60,7 @@ func chatHandler(svc domain.ChatService, conversations domain.ConversationReposi
 			_ = conversations.AppendMessages(r.Context(), convID, toDomainMessages(req.Messages))
 		}
 
-		events, err := svc.Chat(r.Context(), domainID, req.Messages, req.RecordIDs, req.Model)
+		events, err := svc.Chat(r.Context(), domainID, req.Messages, req.RecordIDs, req.Model, req.Debug)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, errBody("chat failed: "+err.Error()))
 			return

--- a/internal/embedder/domain/chat.go
+++ b/internal/embedder/domain/chat.go
@@ -7,7 +7,7 @@ import "context"
 
 // ChatMessage is a single turn in a conversation.
 type ChatMessage struct {
-	Role    string `json:"role"`    // "user" | "assistant"
+	Role    string `json:"role"` // "user" | "assistant"
 	Content string `json:"content"`
 }
 
@@ -26,6 +26,7 @@ type ChatEventType string
 const (
 	ChatEventToken        ChatEventType = "token"
 	ChatEventCitations    ChatEventType = "citations"
+	ChatEventDebug        ChatEventType = "debug"
 	ChatEventError        ChatEventType = "error"
 	ChatEventDone         ChatEventType = "done"
 	ChatEventConversation ChatEventType = "conversation"
@@ -39,8 +40,32 @@ type ChatEvent struct {
 	Type           ChatEventType `json:"type"`
 	Content        string        `json:"content,omitempty"`
 	Citations      []Citation    `json:"citations,omitempty"`
+	Debug          *ChatDebug    `json:"debug,omitempty"`
 	Error          string        `json:"error,omitempty"`
 	ConversationID string        `json:"conversation_id,omitempty"`
+}
+
+// ChatDebug describes the retrieval context used to build the prompt.
+// It is emitted as an optional streaming event and should only be shown in
+// developer/admin UI surfaces.
+type ChatDebug struct {
+	Query            string           `json:"query"`
+	TopK             int              `json:"top_k"`
+	RetrievalEnabled bool             `json:"retrieval_enabled"`
+	SkippedReason    string           `json:"skipped_reason,omitempty"`
+	RecordIDs        []string         `json:"record_ids,omitempty"`
+	PromptChunks     []ChatDebugChunk `json:"prompt_chunks"`
+}
+
+// ChatDebugChunk is one retrieved chunk that was sent to the model.
+type ChatDebugChunk struct {
+	Rank        int      `json:"rank"`
+	RecordID    string   `json:"record_id"`
+	RecordName  string   `json:"record_name"`
+	ExternalURL string   `json:"external_url,omitempty"`
+	ChunkIndex  int      `json:"chunk_index"`
+	Score       *float64 `json:"score,omitempty"`
+	Preview     string   `json:"preview"`
 }
 
 // ModelConfig carries per-request LLM overrides sent by the client.
@@ -69,5 +94,5 @@ type ChatService interface {
 	// streams events to the returned channel.  The channel is closed when the
 	// stream ends (either successfully or after an error event).
 	// modelCfg is optional; nil means use the server-configured default.
-	Chat(ctx context.Context, domainID string, messages []ChatMessage, recordIDs []string, modelCfg *ModelConfig) (<-chan ChatEvent, error)
+	Chat(ctx context.Context, domainID string, messages []ChatMessage, recordIDs []string, modelCfg *ModelConfig, debug bool) (<-chan ChatEvent, error)
 }

--- a/internal/embedder/domain/vector_retrieve.go
+++ b/internal/embedder/domain/vector_retrieve.go
@@ -7,11 +7,12 @@ import "context"
 
 // VectorChunk is a chunk returned by vector similarity search.
 type VectorChunk struct {
-	RecordID    string `json:"record_id"`
-	RecordName  string `json:"record_name"`
-	ExternalURL string `json:"external_url,omitempty"`
-	ChunkIndex  int    `json:"chunk_index"`
-	Content     string `json:"content"`
+	RecordID    string   `json:"record_id"`
+	RecordName  string   `json:"record_name"`
+	ExternalURL string   `json:"external_url,omitempty"`
+	ChunkIndex  int      `json:"chunk_index"`
+	Content     string   `json:"content"`
+	Score       *float64 `json:"score,omitempty"`
 }
 
 // VectorRetrieveService retrieves relevant chunks via embedding similarity.

--- a/internal/embedder/postgres/chunks.go
+++ b/internal/embedder/postgres/chunks.go
@@ -97,6 +97,7 @@ type ChunkSearchResult struct {
 	RecordName  string
 	ExternalURL string
 	ChunkIndex  int
+	Score       *float64
 }
 
 // SearchChunks performs a cosine-distance vector similarity search over the

--- a/internal/embedder/postgres/chunks_search.go
+++ b/internal/embedder/postgres/chunks_search.go
@@ -327,7 +327,7 @@ rrf AS (
 	args = append(args, topK)
 
 	sb.WriteString(`
-SELECT c.content, c.record_id, rec.name, COALESCE(rec.external_url, ''), c.chunk_index
+SELECT c.content, c.record_id, rec.name, COALESCE(rec.external_url, ''), c.chunk_index, rrf.score
 FROM rrf
 JOIN chunks c ON c.id = rrf.chunk_id
 JOIN records rec ON rec.id = c.record_id
@@ -344,9 +344,11 @@ LIMIT `)
 	var results []ChunkSearchResult
 	for rows.Next() {
 		var res ChunkSearchResult
-		if err := rows.Scan(&res.Content, &res.RecordID, &res.RecordName, &res.ExternalURL, &res.ChunkIndex); err != nil {
+		var score float64
+		if err := rows.Scan(&res.Content, &res.RecordID, &res.RecordName, &res.ExternalURL, &res.ChunkIndex, &score); err != nil {
 			return nil, fmt.Errorf("scan chunk: %w", err)
 		}
+		res.Score = &score
 		results = append(results, res)
 	}
 	return results, rows.Err()

--- a/internal/embedder/service/chat.go
+++ b/internal/embedder/service/chat.go
@@ -69,7 +69,7 @@ func NewChatService(retrieve domain.VectorRetrieveService, llmClient llm.Client,
 	return &chatService{retrieve: retrieve, llm: llmClient, reranker: reranker, topK: topK, defaultCfg: defaultCfg, factory: factory}
 }
 
-func (s *chatService) Chat(ctx context.Context, domainID string, messages []domain.ChatMessage, recordIDs []string, modelCfg *domain.ModelConfig) (<-chan domain.ChatEvent, error) {
+func (s *chatService) Chat(ctx context.Context, domainID string, messages []domain.ChatMessage, recordIDs []string, modelCfg *domain.ModelConfig, debug bool) (<-chan domain.ChatEvent, error) {
 	// Build a per-request client if the caller overrides the model.
 	llmClient := s.llm
 	if modelCfg != nil && modelCfg.Model != "" && s.factory != nil {
@@ -100,6 +100,7 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 	var chunks []domain.VectorChunk
 	var retrievalWarning string
 	retrieveForQuery := shouldRetrieve(query)
+	skippedReason := ""
 
 	if retrieveForQuery {
 		var err error
@@ -112,6 +113,7 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 		}
 	}
 	if !retrieveForQuery {
+		skippedReason = "conversational message"
 		slog.Info("chat: skipped retrieval for conversational message")
 	}
 
@@ -218,6 +220,15 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 			}
 		}
 
+		if debug {
+			debugData := buildChatDebug(query, s.topK, retrieveForQuery, skippedReason, recordIDs, chunks)
+			select {
+			case out <- domain.ChatEvent{Type: domain.ChatEventDebug, Debug: &debugData}:
+			case <-ctx.Done():
+				return
+			}
+		}
+
 		tokenCh := make(chan string, 64)
 		errCh := make(chan error, 1)
 
@@ -289,6 +300,32 @@ func matchedRecordsBlock(chunks []domain.VectorChunk) string {
 		b.WriteByte('\n')
 	}
 	return b.String()
+}
+
+func buildChatDebug(query string, topK int, retrievalEnabled bool, skippedReason string, recordIDs []string, chunks []domain.VectorChunk) domain.ChatDebug {
+	if topK <= 0 {
+		topK = 5
+	}
+	debug := domain.ChatDebug{
+		Query:            query,
+		TopK:             topK,
+		RetrievalEnabled: retrievalEnabled,
+		SkippedReason:    skippedReason,
+		RecordIDs:        append([]string(nil), recordIDs...),
+		PromptChunks:     make([]domain.ChatDebugChunk, 0, len(chunks)),
+	}
+	for i, c := range chunks {
+		debug.PromptChunks = append(debug.PromptChunks, domain.ChatDebugChunk{
+			Rank:        i + 1,
+			RecordID:    c.RecordID,
+			RecordName:  c.RecordName,
+			ExternalURL: c.ExternalURL,
+			ChunkIndex:  c.ChunkIndex,
+			Score:       c.Score,
+			Preview:     truncate(c.Content, 280),
+		})
+	}
+	return debug
 }
 
 func truncate(s string, n int) string {

--- a/internal/embedder/service/chat_test.go
+++ b/internal/embedder/service/chat_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 type chatRetrieveStub struct {
-	calls int
+	calls  int
+	chunks []domain.VectorChunk
 }
 
 func (s *chatRetrieveStub) Retrieve(context.Context, string, string, []string, int) ([]domain.VectorChunk, error) {
 	s.calls++
-	return nil, nil
+	return s.chunks, nil
 }
 
 type chatLLMStub struct {
@@ -61,7 +62,7 @@ func TestChatSkipsRetrievalForConversationalMessage(t *testing.T) {
 
 	events, err := service.Chat(context.Background(), "domain", []domain.ChatMessage{
 		{Role: "user", Content: "hello!"},
-	}, nil, nil)
+	}, nil, nil, false)
 	if err != nil {
 		t.Fatalf("chat failed: %v", err)
 	}
@@ -73,6 +74,53 @@ func TestChatSkipsRetrievalForConversationalMessage(t *testing.T) {
 	}
 	if len(client.messages) == 0 || client.messages[0].Content != conversationSystemPrompt {
 		t.Fatal("expected conversational system prompt")
+	}
+}
+
+func TestChatEmitsRetrievalDebug(t *testing.T) {
+	score := 0.42
+	retrieve := &chatRetrieveStub{chunks: []domain.VectorChunk{{
+		RecordID:   "record-1",
+		RecordName: "DusanEUCNC.pdf",
+		ChunkIndex: 2,
+		Content:    "Dusan Borovcanin invoice details",
+		Score:      &score,
+	}}}
+	client := &chatLLMStub{}
+	service := NewChatService(retrieve, client, nil, 5, llm.Config{}, nil)
+
+	events, err := service.Chat(context.Background(), "domain", []domain.ChatMessage{
+		{Role: "user", Content: "dusan"},
+	}, []string{"record-1"}, nil, true)
+	if err != nil {
+		t.Fatalf("chat failed: %v", err)
+	}
+
+	var debug *domain.ChatDebug
+	for ev := range events {
+		if ev.Type == domain.ChatEventDebug {
+			debug = ev.Debug
+		}
+	}
+
+	if debug == nil {
+		t.Fatal("expected retrieval debug event")
+	}
+	if debug.Query != "dusan" || !debug.RetrievalEnabled || debug.TopK != 5 {
+		t.Fatalf("unexpected debug metadata: %+v", *debug)
+	}
+	if len(debug.RecordIDs) != 1 || debug.RecordIDs[0] != "record-1" {
+		t.Fatalf("unexpected debug record scope: %+v", debug.RecordIDs)
+	}
+	if len(debug.PromptChunks) != 1 {
+		t.Fatalf("expected one debug chunk, got %d", len(debug.PromptChunks))
+	}
+	chunk := debug.PromptChunks[0]
+	if chunk.Rank != 1 || chunk.RecordName != "DusanEUCNC.pdf" || chunk.ChunkIndex != 2 {
+		t.Fatalf("unexpected debug chunk: %+v", chunk)
+	}
+	if chunk.Score == nil || *chunk.Score != score {
+		t.Fatalf("expected score %v, got %v", score, chunk.Score)
 	}
 }
 

--- a/internal/embedder/service/vector_retrieve.go
+++ b/internal/embedder/service/vector_retrieve.go
@@ -88,6 +88,7 @@ func (s *vectorRetrieveService) Retrieve(ctx context.Context, domainID, query st
 			ExternalURL: r.ExternalURL,
 			ChunkIndex:  r.ChunkIndex,
 			Content:     r.Content,
+			Score:       r.Score,
 		}
 	}
 	return chunks, nil

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -61,6 +61,7 @@ export default function App() {
         <Route path="/records" element={<RecordsPage />} />
         <Route path="/sources" element={<SourcesPage />} />
         <Route path="/chat" element={<ChatPage />} />
+        <Route path="/prompt" element={<ChatPage />} />
         <Route path="/config" element={<ConfigPage />} />
         <Route path="/domains" element={<DomainsPage />} />
         <Route path="/members" element={<MembersPage />} />

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Ultraviolet
 // SPDX-License-Identifier: Apache-2.0
-import type { AppRecord } from '@/types'
+import type { AppRecord, ChatDebug } from '@/types'
 
 export interface ChatMessage {
   role: 'user' | 'assistant'
@@ -15,12 +15,13 @@ export interface Citation {
   excerpt: string
 }
 
-export type ChatEventType = 'token' | 'citations' | 'error' | 'done' | 'conversation' | 'warning'
+export type ChatEventType = 'token' | 'citations' | 'debug' | 'error' | 'done' | 'conversation' | 'warning'
 
 export interface ChatEvent {
   type: ChatEventType
   content?: string
   citations?: Citation[]
+  debug?: ChatDebug
   error?: string
   conversation_id?: string
 }
@@ -56,6 +57,7 @@ export function streamChat(
   signal?: AbortSignal,
   conversationId?: string | null,
   modelConfig?: BackendModelConfig | null,
+  debug?: boolean,
 ): Promise<void> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -70,6 +72,7 @@ export function streamChat(
       record_ids: recordIDs,
       conversation_id: conversationId ?? undefined,
       model: modelConfig ?? undefined,
+      debug: debug || undefined,
     }),
     signal,
   }).then(async (res) => {

--- a/ui/src/pages/ChatPage.tsx
+++ b/ui/src/pages/ChatPage.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { useOutletContext, useLocation } from 'react-router-dom'
-import type { AppContext, AppRecord, ChatMessage, Conversation, MsgSource } from '@/types'
+import type { AppContext, AppRecord, ChatDebug, ChatMessage, Conversation, MsgSource } from '@/types'
 import UserMenu from '@/components/UserMenu'
 import { useAuth } from '@/hooks/useAuth'
 import { listOllamaModels, streamChat } from '@/lib/api'
@@ -39,6 +39,10 @@ function citationToSource(c: Citation): MsgSource {
 function citationCounts(citations: MsgSource[]) {
   const records = new Set(citations.map(citation => citation.recordID || citation.doc))
   return { records: records.size, chunks: citations.length }
+}
+
+function formatScore(score?: number) {
+  return typeof score === 'number' ? score.toFixed(4) : 'n/a'
 }
 
 type ModelStatus = 'checking' | 'connected' | 'configured' | 'model-unavailable' | 'provider-unavailable' | 'server-default'
@@ -236,6 +240,8 @@ function SourcesPanel({
   canCustomizeSources,
   onToggle,
   citations,
+  debug,
+  debugEnabled,
   selectedSourceID,
   isSyncingSelectedSource,
   onSyncSource,
@@ -246,6 +252,8 @@ function SourcesPanel({
   canCustomizeSources: boolean
   onToggle: (id: string) => void
   citations: MsgSource[]
+  debug?: ChatDebug | null
+  debugEnabled?: boolean
   selectedSourceID?: string
   isSyncingSelectedSource?: boolean
   onSyncSource?: () => void
@@ -335,6 +343,49 @@ function SourcesPanel({
           </div>
         </>
       )}
+
+      {debugEnabled && (
+        <>
+          <div style={{ height: '1px', background: 'var(--border)', flexShrink: 0 }} />
+          <div style={{ flexShrink: 0, padding: '12px 14px 8px' }}>
+            <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '9px', color: 'var(--text-dim)', letterSpacing: '0.1em' }}>
+              DEBUG · RETRIEVAL
+            </span>
+          </div>
+          <div style={{ flex: citations.length > 0 ? '0 0 45%' : '1', overflowY: 'auto', padding: '0 8px 12px' }}>
+            {debug ? (
+              <>
+                <div style={{ marginBottom: '8px', background: 'rgba(0,212,180,0.04)', border: '1px solid rgba(0,212,180,0.15)', borderRadius: '8px', padding: '9px 10px' }}>
+                  <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '8px', color: 'var(--text-dim)', marginBottom: '5px', letterSpacing: '0.08em' }}>QUERY</div>
+                  <div style={{ fontFamily: 'Space Grotesk, sans-serif', fontSize: '11px', color: 'var(--text-muted)', lineHeight: 1.5 }}>{debug.query || 'empty'}</div>
+                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginTop: '8px', fontFamily: 'JetBrains Mono, monospace', fontSize: '9px', color: 'var(--text-dim)' }}>
+                    <span>topK {debug.top_k}</span>
+                    <span>{debug.retrieval_enabled ? 'retrieval on' : `retrieval skipped${debug.skipped_reason ? `: ${debug.skipped_reason}` : ''}`}</span>
+                    {debug.record_ids && debug.record_ids.length > 0 && <span>scoped records {debug.record_ids.length}</span>}
+                  </div>
+                </div>
+                {debug.prompt_chunks.length === 0 ? (
+                  <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: 'var(--text-dim)', padding: '8px 4px' }}>No chunks sent to the model.</div>
+                ) : debug.prompt_chunks.map(chunk => (
+                  <div key={`${chunk.record_id}-${chunk.chunk_index}-${chunk.rank}`} style={{ marginBottom: '8px', background: 'rgba(255,255,255,0.03)', border: '1px solid var(--border)', borderRadius: '8px', padding: '9px 10px' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '5px' }}>
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '9px', color: 'var(--accent)', flexShrink: 0 }}>#{chunk.rank}</span>
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '9px', color: 'var(--text-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{chunk.record_name}</span>
+                      <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '9px', color: 'var(--text-dim)', flexShrink: 0 }}>s {formatScore(chunk.score)}</span>
+                    </div>
+                    <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '8px', color: 'var(--text-dim)', marginBottom: '5px' }}>chunk {chunk.chunk_index}</div>
+                    <div style={{ fontFamily: 'Space Grotesk, sans-serif', fontSize: '11px', color: 'var(--text-muted)', lineHeight: 1.6, fontStyle: 'italic' }}>
+                      "{chunk.preview}"
+                    </div>
+                  </div>
+                ))}
+              </>
+            ) : (
+              <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '10px', color: 'var(--text-dim)', padding: '8px 4px' }}>Ask a question to see retrieval details.</div>
+            )}
+          </div>
+        </>
+      )}
     </div>
   )
 }
@@ -345,6 +396,7 @@ export default function ChatPage() {
   const location = useLocation()
   const accessToken = tokens?.accessToken
   const domainID = activeDomain?.id ?? ''
+  const debugEnabled = new URLSearchParams(location.search).get('debug') === '1'
   const routeState = (location.state ?? null) as ChatRouteState | null
   const selectedRecord = routeState?.source
   const selectedSourceID = routeState?.sourceID
@@ -365,6 +417,7 @@ export default function ChatPage() {
   const [manualActiveSources, setManualActiveSources] = useState<string[] | null>(null)
   const [showPanel, setShowPanel] = useState(true)
   const [panelCitations, setPanelCitations] = useState<MsgSource[]>([])
+  const [panelDebug, setPanelDebug] = useState<ChatDebug | null>(null)
   const [modelConfig, setModelConfig] = useState(loadModelConfig)
   const [externalProviderConfig] = useState(loadExternalModelConfig)
   const [modelStatus, setModelStatus] = useState<ModelStatus>(() => initialModelStatus(loadModelConfig()))
@@ -411,6 +464,17 @@ export default function ChatPage() {
       }
     }
   }, [chatMessages])
+
+  useEffect(() => {
+    if (!debugEnabled) return
+    for (let i = chatMessages.length - 1; i >= 0; i--) {
+      if (chatMessages[i].role === 'assistant' && chatMessages[i].debug) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setPanelDebug(chatMessages[i].debug!)
+        return
+      }
+    }
+  }, [chatMessages, debugEnabled])
 
   const handleSelectConversation = useCallback(async (id: string) => {
     if (!accessToken || loadingConv) return
@@ -562,6 +626,7 @@ export default function ChatPage() {
     setInput('')
     setLoading(true)
     setRetrievalWarning(null)
+    if (debugEnabled) setPanelDebug(null)
 
     const history: ChatMessage[] = [...chatMessages, { id: Date.now(), role: 'user', content: userContent }]
     setChatMessages(history)
@@ -599,6 +664,12 @@ export default function ChatPage() {
           setChatMessages(prev => prev.map(m =>
             m.id === assistantId ? { ...m, sources } : m
           ))
+        } else if (event.type === 'debug' && event.debug) {
+          setPanelDebug(event.debug)
+          setShowPanel(true)
+          setChatMessages(prev => prev.map(m =>
+            m.id === assistantId ? { ...m, debug: event.debug } : m
+          ))
         } else if (event.type === 'done') {
           setLoading(false)
         } else if (event.type === 'error') {
@@ -613,6 +684,7 @@ export default function ChatPage() {
       controller.signal,
       conversationId,
       toBackendModelConfig(modelConfig),
+      debugEnabled,
     ).catch((err) => {
       if (err.name !== 'AbortError') {
         setChatMessages(prev => prev.map(m =>
@@ -623,7 +695,7 @@ export default function ChatPage() {
       }
       setLoading(false)
     })
-  }, [input, loading, chatMessages, setChatMessages, accessToken, domainID, activeSources, selectedRecord, selectedRecordNotIndexed, selectedSourceID, conversationId, setConversationId, setConversations, modelConfig])
+  }, [input, loading, chatMessages, setChatMessages, accessToken, domainID, activeSources, selectedRecord, selectedRecordNotIndexed, selectedSourceID, conversationId, setConversationId, setConversations, modelConfig, debugEnabled])
 
   const indexedSources = records.filter(s => s.status === 'indexed')
   const modelStatusInfo = modelStatusDetails(modelConfig, modelStatus)
@@ -865,6 +937,8 @@ export default function ChatPage() {
           canCustomizeSources={canCustomizeSources}
           onToggle={handleToggleSource}
           citations={panelCitations}
+          debug={panelDebug}
+          debugEnabled={debugEnabled}
           selectedSourceID={selectedSourceID}
           isSyncingSelectedSource={isSyncingSelectedSource}
           onSyncSource={() => { void handleSyncSelectedSource() }}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -22,11 +22,31 @@ export interface MsgSource {
   url?: string
 }
 
+export interface ChatDebugChunk {
+  rank: number
+  record_id: string
+  record_name: string
+  external_url?: string
+  chunk_index: number
+  score?: number
+  preview: string
+}
+
+export interface ChatDebug {
+  query: string
+  top_k: number
+  retrieval_enabled: boolean
+  skipped_reason?: string
+  record_ids?: string[]
+  prompt_chunks: ChatDebugChunk[]
+}
+
 export interface ChatMessage {
   id: number
   role: 'user' | 'assistant'
   content: string
   sources?: MsgSource[]
+  debug?: ChatDebug
 }
 
 export interface AppRecord {


### PR DESCRIPTION
# What type of PR is this?

This is a feature that adds a hidden retrieval debug panel for inspecting chat retrieval behavior.

## What does this do?

  - Adds an optional chat debug event emitted only when the request enables debug mode.
  - Adds a hidden Prompt debug mode behind ?debug=1.
  - Shows retrieval details in the right-side panel:
      - query
      - topK
      - retrieval enabled/skipped state
      - scoped record count
      - prompt chunk rank
      - record name
      - chunk index

  - Propagates RRF retrieval score from backend search results into debug metadata.
  - Adds /prompt as an alias for the existing chat page so /prompt?debug=1 works.
  - Keeps normal Prompt UI unchanged when debug mode is not enabled.

## Which issue(s) does this PR fix/relate to?

  - Related Issue: NOISSUE

## Have you included tests for your changes?

Yes. Added backend service coverage for retrieval debug event emission.

The following checks were completed:

  - go test ./internal/embedder/...
  - npm run build
  - npm run lint -- src/App.tsx src/pages/ChatPage.tsx src/lib/api.ts src/types/index.ts
  - npm test -- --run

## Did you document any new/modified features?

No separate documentation was added. The feature is intentionally hidden behind /prompt?debug=1 for developer/admin troubleshooting.

### Notes

Manually verified the debug panel with mart query and confirmed retrieved prompt chunks, rank, score, and previews are displayed.
