### PR TITLE
NOISSUE - Gate visual retrieval by query intent

### DIFF
--- a/internal/embedder/service/vector_retrieve.go
+++ b/internal/embedder/service/vector_retrieve.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/ultravioletrs/cube/internal/embedder/domain"
 	"github.com/ultravioletrs/cube/internal/embedder/embedding"
@@ -68,7 +69,7 @@ func (s *vectorRetrieveService) Retrieve(ctx context.Context, domainID, query st
 		return nil, fmt.Errorf("search chunks: %w", err)
 	}
 
-	if s.imageEmbeddings != nil && s.imageEmbedder != nil {
+	if s.imageEmbeddings != nil && s.imageEmbedder != nil && hasVisualIntent(query) {
 		imageQuery, err := s.imageEmbedder.EmbedText(ctx, query)
 		if err != nil {
 			return nil, fmt.Errorf("embed visual query: %w", err)
@@ -92,6 +93,47 @@ func (s *vectorRetrieveService) Retrieve(ctx context.Context, domainID, query st
 		}
 	}
 	return chunks, nil
+}
+
+func hasVisualIntent(query string) bool {
+	normalized := strings.ToLower(strings.Join(strings.Fields(query), " "))
+	if normalized == "" {
+		return false
+	}
+	visualTerms := []string{
+		"describe image",
+		"describe the image",
+		"describe picture",
+		"describe the picture",
+		"describe photo",
+		"describe the photo",
+		"describe screenshot",
+		"describe the screenshot",
+		"what is shown",
+		"what's shown",
+		"what is in this image",
+		"what is in the image",
+		"what is in this picture",
+		"what is in the picture",
+		"image",
+		"images",
+		"picture",
+		"pictures",
+		"photo",
+		"photos",
+		"screenshot",
+		"screenshots",
+		"scan",
+		"scans",
+		"visual",
+		"visually",
+	}
+	for _, term := range visualTerms {
+		if strings.Contains(normalized, term) {
+			return true
+		}
+	}
+	return false
 }
 
 func interleaveChunkResults(textResults, imageResults []postgres.ChunkSearchResult, topK int) []postgres.ChunkSearchResult {


### PR DESCRIPTION
# What type of PR is this?

This is a bug fix because it reduces noisy visual image retrieval results for normal text-based chat questions.

## What does this do?

This PR gates visual image embedding retrieval behind a lightweight visual-intent check.

Previously, multimodal retrieval always searched both text chunks and visual image embeddings whenever image embeddings were configured. That could cause unrelated image-
only matches to appear for ordinary text queries, for example when the user is asking about a date, invoice, payment, contract, or record name.

With this change:
  - text and OCR chunk retrieval still run for every query
  - image records can still be found through extracted OCR/text content
  - visual image embedding retrieval only runs when the query appears to be asking about images, screenshots, scans, photos, or visual content
  - normal document questions are less likely to receive unrelated “Visual image match” context

## Which issue(s) does this PR fix/relate to?

N/A

## Have you included tests for your changes?

No, I have not included new tests for this change. The update is intentionally small and was manually tested through the prompt retrieval/debug flow.

## Did you document any new/modified features?

No, this is an internal retrieval behavior fix and does not add a user-facing feature.

### Notes

This is a pragmatic guard to reduce noisy multimodal retrieval. It does not remove OCR/text retrieval for image records; it only avoids running visual embedding search for
clearly non-visual questions.
