### PR TITLE
NOISSUE - Guard chat against weak retrieval context

### DIFF
--- a/internal/embedder/service/chat.go
+++ b/internal/embedder/service/chat.go
@@ -36,6 +36,8 @@ const conversationSystemPrompt = `You are a helpful assistant.
 Respond naturally to conversational messages.
 Do not claim to have searched, found, or used records when no document excerpts are provided.`
 
+const noRelevantContextResponse = "I couldn't find relevant information in the indexed records for that question. Please narrow the question or select a specific record or source."
+
 var conversationalMessages = map[string]struct{}{
 	"good afternoon":  {},
 	"good evening":    {},
@@ -99,6 +101,8 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 	var citations []domain.Citation
 	var chunks []domain.VectorChunk
 	var retrievalWarning string
+	noRelevantContext := false
+	weakContext := false
 	retrieveForQuery := shouldRetrieve(query)
 	skippedReason := ""
 
@@ -109,7 +113,14 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 			retrievalWarning = "Retrieval failed: " + err.Error() + " — answering without document context."
 			chunks = nil
 		} else if len(chunks) == 0 {
-			retrievalWarning = "No relevant chunks found in indexed records — answering without document context."
+			retrievalWarning = "No relevant chunks found in indexed records."
+			noRelevantContext = true
+		} else {
+			chunks = lexicallyGroundedChunks(query, chunks)
+			if len(chunks) == 0 {
+				retrievalWarning = "Retrieved chunks did not appear relevant enough to answer from indexed records."
+				weakContext = true
+			}
 		}
 	}
 	if !retrieveForQuery {
@@ -229,6 +240,19 @@ func (s *chatService) Chat(ctx context.Context, domainID string, messages []doma
 			}
 		}
 
+		if noRelevantContext || weakContext {
+			select {
+			case out <- domain.ChatEvent{Type: domain.ChatEventToken, Content: noRelevantContextResponse}:
+			case <-ctx.Done():
+				return
+			}
+			select {
+			case out <- domain.ChatEvent{Type: domain.ChatEventDone}:
+			case <-ctx.Done():
+			}
+			return
+		}
+
 		tokenCh := make(chan string, 64)
 		errCh := make(chan error, 1)
 
@@ -300,6 +324,56 @@ func matchedRecordsBlock(chunks []domain.VectorChunk) string {
 		b.WriteByte('\n')
 	}
 	return b.String()
+}
+
+func hasLexicalGrounding(query string, chunks []domain.VectorChunk) bool {
+	return len(lexicallyGroundedChunks(query, chunks)) > 0
+}
+
+func lexicallyGroundedChunks(query string, chunks []domain.VectorChunk) []domain.VectorChunk {
+	terms := meaningfulQueryTerms(query)
+	if len(terms) == 0 {
+		return nil
+	}
+	grounded := make([]domain.VectorChunk, 0, len(chunks))
+	for _, c := range chunks {
+		haystack := strings.ToLower(c.RecordName + " " + c.Content)
+		for _, term := range terms {
+			if strings.Contains(haystack, term) {
+				grounded = append(grounded, c)
+				break
+			}
+		}
+	}
+	return grounded
+}
+
+func meaningfulQueryTerms(query string) []string {
+	stopwords := map[string]struct{}{
+		"about": {}, "after": {}, "again": {}, "also": {}, "and": {}, "any": {}, "are": {}, "can": {}, "could": {}, "details": {}, "did": {}, "document": {}, "documents": {}, "does": {}, "file": {}, "files": {}, "for": {}, "from": {}, "give": {}, "has": {}, "have": {}, "how": {}, "into": {}, "its": {}, "more": {}, "please": {}, "record": {}, "records": {}, "show": {}, "some": {}, "tell": {}, "that": {}, "the": {}, "their": {}, "them": {}, "there": {}, "this": {}, "was": {}, "what": {}, "when": {}, "where": {}, "which": {}, "with": {}, "would": {}, "you": {},
+	}
+	seen := make(map[string]struct{})
+	terms := make([]string, 0, 8)
+	for _, field := range strings.Fields(strings.ToLower(query)) {
+		term := strings.TrimFunc(field, func(r rune) bool {
+			return unicode.IsPunct(r) || unicode.IsSpace(r)
+		})
+		if len(term) < 3 {
+			continue
+		}
+		if _, skip := stopwords[term]; skip {
+			continue
+		}
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		terms = append(terms, term)
+		if len(terms) >= 8 {
+			break
+		}
+	}
+	return terms
 }
 
 func buildChatDebug(query string, topK int, retrievalEnabled bool, skippedReason string, recordIDs []string, chunks []domain.VectorChunk) domain.ChatDebug {

--- a/internal/embedder/service/chat_test.go
+++ b/internal/embedder/service/chat_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/ultravioletrs/cube/internal/embedder/domain"
@@ -22,10 +23,12 @@ func (s *chatRetrieveStub) Retrieve(context.Context, string, string, []string, i
 }
 
 type chatLLMStub struct {
+	calls    int
 	messages []llm.Message
 }
 
 func (s *chatLLMStub) StreamChat(_ context.Context, messages []llm.Message, out chan<- string) error {
+	s.calls++
 	s.messages = messages
 	close(out)
 	return nil
@@ -77,20 +80,150 @@ func TestChatSkipsRetrievalForConversationalMessage(t *testing.T) {
 	}
 }
 
+func TestChatDoesNotCallLLMWhenRetrievalFindsNoChunks(t *testing.T) {
+	retrieve := &chatRetrieveStub{}
+	client := &chatLLMStub{}
+	service := NewChatService(retrieve, client, nil, 8, llm.Config{}, nil)
+
+	events, err := service.Chat(context.Background(), "domain", []domain.ChatMessage{
+		{Role: "user", Content: "record details"},
+	}, nil, nil, true)
+	if err != nil {
+		t.Fatalf("chat failed: %v", err)
+	}
+
+	var gotToken string
+	var gotDone bool
+	var gotDebug bool
+	for ev := range events {
+		switch ev.Type {
+		case domain.ChatEventToken:
+			gotToken += ev.Content
+		case domain.ChatEventDone:
+			gotDone = true
+		case domain.ChatEventDebug:
+			gotDebug = true
+		}
+	}
+
+	if retrieve.calls != 1 {
+		t.Fatalf("expected retrieval to run once, got %d calls", retrieve.calls)
+	}
+	if client.calls != 0 {
+		t.Fatalf("expected LLM call to be skipped, got %d calls", client.calls)
+	}
+	if gotToken != noRelevantContextResponse {
+		t.Fatalf("unexpected fallback response: %q", gotToken)
+	}
+	if !gotDone {
+		t.Fatal("expected done event")
+	}
+	if !gotDebug {
+		t.Fatal("expected debug event")
+	}
+}
+
+func TestChatDoesNotCallLLMWhenRetrievedChunksAreWeak(t *testing.T) {
+	retrieve := &chatRetrieveStub{chunks: []domain.VectorChunk{{
+		RecordID:   "record-1",
+		RecordName: "record_a.pdf",
+		ChunkIndex: 1,
+		Content:    "Unrelated retrieved content",
+	}}}
+	client := &chatLLMStub{}
+	service := NewChatService(retrieve, client, nil, 8, llm.Config{}, nil)
+
+	events, err := service.Chat(context.Background(), "domain", []domain.ChatMessage{
+		{Role: "user", Content: "specific external topic"},
+	}, nil, nil, true)
+	if err != nil {
+		t.Fatalf("chat failed: %v", err)
+	}
+
+	var gotToken string
+	var gotWarning bool
+	var gotDebug bool
+	for ev := range events {
+		switch ev.Type {
+		case domain.ChatEventToken:
+			gotToken += ev.Content
+		case domain.ChatEventWarning:
+			gotWarning = true
+		case domain.ChatEventDebug:
+			gotDebug = true
+		}
+	}
+
+	if client.calls != 0 {
+		t.Fatalf("expected LLM call to be skipped, got %d calls", client.calls)
+	}
+	if gotToken != noRelevantContextResponse {
+		t.Fatalf("unexpected fallback response: %q", gotToken)
+	}
+	if !gotWarning {
+		t.Fatal("expected warning event")
+	}
+	if !gotDebug {
+		t.Fatal("expected debug event")
+	}
+}
+
+func TestChatFiltersWeakChunksBeforeCallingLLM(t *testing.T) {
+	retrieve := &chatRetrieveStub{chunks: []domain.VectorChunk{
+		{
+			RecordID:   "record-1",
+			RecordName: "record_a.pdf",
+			ChunkIndex: 1,
+			Content:    "Relevant alpha details",
+		},
+		{
+			RecordID:   "record-2",
+			RecordName: "record_b.pdf",
+			ChunkIndex: 1,
+			Content:    "Unrelated retrieved content",
+		},
+	}}
+	client := &chatLLMStub{}
+	service := NewChatService(retrieve, client, nil, 8, llm.Config{}, nil)
+
+	events, err := service.Chat(context.Background(), "domain", []domain.ChatMessage{
+		{Role: "user", Content: "alpha topic"},
+	}, nil, nil, true)
+	if err != nil {
+		t.Fatalf("chat failed: %v", err)
+	}
+	for range events {
+	}
+
+	if client.calls != 1 {
+		t.Fatalf("expected one LLM call, got %d", client.calls)
+	}
+	if len(client.messages) < 2 {
+		t.Fatalf("expected system and user messages, got %d", len(client.messages))
+	}
+	prompt := client.messages[1].Content
+	if !strings.Contains(prompt, "record_a.pdf") {
+		t.Fatalf("expected grounded chunk in prompt: %q", prompt)
+	}
+	if strings.Contains(prompt, "record_b.pdf") || strings.Contains(prompt, "Unrelated retrieved content") {
+		t.Fatalf("expected weak chunk to be filtered from prompt: %q", prompt)
+	}
+}
+
 func TestChatEmitsRetrievalDebug(t *testing.T) {
 	score := 0.42
 	retrieve := &chatRetrieveStub{chunks: []domain.VectorChunk{{
 		RecordID:   "record-1",
 		RecordName: "record_a.pdf",
 		ChunkIndex: 2,
-		Content:    "Example retrieved chunk",
+		Content:    "Example alpha retrieved chunk",
 		Score:      &score,
 	}}}
 	client := &chatLLMStub{}
 	service := NewChatService(retrieve, client, nil, 5, llm.Config{}, nil)
 
 	events, err := service.Chat(context.Background(), "domain", []domain.ChatMessage{
-		{Role: "user", Content: "record details"},
+		{Role: "user", Content: "alpha details"},
 	}, []string{"record-1"}, nil, true)
 	if err != nil {
 		t.Fatalf("chat failed: %v", err)
@@ -106,7 +239,7 @@ func TestChatEmitsRetrievalDebug(t *testing.T) {
 	if debug == nil {
 		t.Fatal("expected retrieval debug event")
 	}
-	if debug.Query != "record details" || !debug.RetrievalEnabled || debug.TopK != 5 {
+	if debug.Query != "alpha details" || !debug.RetrievalEnabled || debug.TopK != 5 {
 		t.Fatalf("unexpected debug metadata: %+v", *debug)
 	}
 	if len(debug.RecordIDs) != 1 || debug.RecordIDs[0] != "record-1" {
@@ -135,5 +268,22 @@ func TestMatchedRecordsBlockDeduplicatesRecordNames(t *testing.T) {
 	want := "- record_a.pdf\n- record_b.pdf\n"
 	if got != want {
 		t.Fatalf("unexpected records block:\nwant %q\ngot  %q", want, got)
+	}
+}
+
+func TestHasLexicalGroundingMatchesRecordNameOrContent(t *testing.T) {
+	chunks := []domain.VectorChunk{{
+		RecordName: "record_a.pdf",
+		Content:    "Example alpha chunk",
+	}}
+
+	if !hasLexicalGrounding("alpha request", chunks) {
+		t.Fatal("expected content to ground query")
+	}
+	if !hasLexicalGrounding("alpha details", chunks) {
+		t.Fatal("expected content to ground query")
+	}
+	if hasLexicalGrounding("external topic", chunks) {
+		t.Fatal("expected unrelated query to be weak")
 	}
 }


### PR DESCRIPTION
# What type of PR is this?

This is a bug fix because it prevents chat responses from being generated from empty or weak retrieval context.

## What does this do?

This PR improves grounded chat behavior when retrieval returns no useful context.

Previously, if retrieval returned no chunks or returned unrelated chunks, the chat service could still call the LLM. That allowed the model to produce weak or misleading
answers from irrelevant records.

With this change:
  - chat skips the LLM call when retrieval finds no chunks
  - chat skips the LLM call when retrieved chunks do not appear lexically relevant to the user query
  - weak chunks are filtered out before building the RAG prompt
  - only grounded chunks are sent to the LLM
  - users receive a clear fallback message when indexed records do not contain relevant information
  - debug/citation behavior remains available for inspecting retrieval results

## Which issue(s) does this PR fix/relate to?

N/A

## Have you included tests for your changes?

Yes, I have included tests for this change.

The tests cover:
  - skipping the LLM call when retrieval returns no chunks
  - skipping the LLM call when retrieved chunks are weak/unrelated
  - filtering weak chunks before building the LLM prompt
  - lexical grounding through record names or chunk content

Verified with:
  - `go test ./internal/embedder/service`
  - `go test ./internal/embedder/...`

## Did you document any new/modified features?

No, this is an internal chat retrieval behavior fix and does not add a new user-facing feature.

### Notes

Manually verified that unrelated questions now return a no-relevant-information response, while relevant queries such as record/person name lookups only pass matching
chunks to the model.

